### PR TITLE
feat(api): preserve bookmarks across inputs in PdfMerge

### DIFF
--- a/jpdfium/src/main/java/stirling/software/jpdfium/PdfMerge.java
+++ b/jpdfium/src/main/java/stirling/software/jpdfium/PdfMerge.java
@@ -1,5 +1,8 @@
 package stirling.software.jpdfium;
 
+import stirling.software.jpdfium.doc.Bookmark;
+import stirling.software.jpdfium.doc.PdfBookmarkEditor;
+import stirling.software.jpdfium.doc.PdfBookmarkEditor.BookmarkTree;
 import stirling.software.jpdfium.doc.PdfPageImporter;
 
 import java.lang.foreign.MemorySegment;
@@ -11,14 +14,22 @@ import java.util.List;
  * Merge multiple PDF documents into one.
  *
  * <pre>{@code
- * // Merge from open documents
+ * // Fast path - merge pages only. Bookmarks from inputs 2..N are NOT preserved
+ * // because PDFium's FPDF_ImportPages copies pages but not the outline tree.
  * PdfDocument merged = PdfMerge.merge(List.of(doc1, doc2, doc3));
  * merged.save(Path.of("merged.pdf"));
  *
- * // Merge from file paths
+ * // Merge from file paths (same caveat as merge above)
  * PdfDocument merged = PdfMerge.mergeFiles(List.of(
  *     Path.of("a.pdf"), Path.of("b.pdf"), Path.of("c.pdf")));
  * merged.save(Path.of("merged.pdf"));
+ *
+ * // Preserving path - merges and transfers bookmarks from every input,
+ * // translating page indices so each bookmark still points at the correct
+ * // page in the merged output. Requires qpdf on PATH (same dependency as
+ * // PdfBookmarkEditor.setBookmarks).
+ * byte[] mergedBytes = PdfMerge.mergeWithBookmarks(List.of(doc1, doc2, doc3));
+ * Files.write(Path.of("merged.pdf"), mergedBytes);
  * }</pre>
  */
 public final class PdfMerge {
@@ -95,5 +106,97 @@ public final class PdfMerge {
                 doc.close();
             }
         }
+    }
+
+    /**
+     * Merge multiple documents AND preserve their bookmarks.
+     *
+     * <p>{@link #merge(List)} uses PDFium's {@code FPDF_ImportPages} which copies pages
+     * but not the outline (bookmark) tree, so any bookmarks in inputs 2..N are silently
+     * lost. This variant additionally walks each source's bookmark tree, translates each
+     * GOTO destination's page index by the running offset of that source's pages in the
+     * merged output, and reconstructs them on the merged document via
+     * {@link PdfBookmarkEditor#setBookmarks}.
+     *
+     * <p>The resulting outline is intentionally flat (PDFium's writer path in this
+     * library does not yet emit nested {@code /First} / {@code /Last} subtrees), so a
+     * deeply nested source tree is flattened by depth-first traversal. Bookmarks whose
+     * target is non-internal (URI / LAUNCH / REMOTE_GOTO) are dropped because their
+     * destinations don't translate meaningfully into the merged document.
+     *
+     * <p>The output's {@code /Info} dictionary inherits from the first input — same
+     * behaviour as {@link #merge(List)} — so Title / Author / Subject of the leading
+     * document survive untouched.
+     *
+     * <p>Requires {@code qpdf} on PATH (used by {@link PdfBookmarkEditor#setBookmarks}).
+     *
+     * @param documents documents to merge, in order
+     * @return PDF bytes of the merged document with bookmarks preserved
+     * @throws IllegalArgumentException if the list is empty
+     */
+    public static byte[] mergeWithBookmarks(List<PdfDocument> documents) {
+        if (documents.isEmpty()) {
+            throw new IllegalArgumentException("At least one document is required");
+        }
+
+        // Collect a flat list of all internal (GOTO) bookmarks with translated page
+        // indices BEFORE the merge so we still have access to the source page counts.
+        BookmarkTree.Builder treeBuilder = BookmarkTree.builder();
+        int pageOffset = 0;
+        boolean anyBookmarks = false;
+        for (PdfDocument src : documents) {
+            for (Bookmark bm : src.bookmarks()) {
+                anyBookmarks |= flattenInto(bm, pageOffset, treeBuilder);
+            }
+            pageOffset += src.pageCount();
+        }
+
+        try (PdfDocument merged = merge(documents)) {
+            // If no source had bookmarks we'd be paying the qpdf round-trip for nothing.
+            // saveBytes() preserves first-input metadata via the catalog inheritance
+            // already done by merge(), so the output matches what merge() returns.
+            if (!anyBookmarks) {
+                return merged.saveBytes();
+            }
+            return PdfBookmarkEditor.setBookmarks(merged, treeBuilder.build());
+        }
+    }
+
+    /**
+     * File-path overload of {@link #mergeWithBookmarks(List)}. Opens each input, merges
+     * with bookmark transfer, and closes all sources.
+     */
+    public static byte[] mergeFilesWithBookmarks(List<Path> paths) {
+        if (paths.isEmpty()) {
+            throw new IllegalArgumentException("At least one file path is required");
+        }
+        List<PdfDocument> docs = new ArrayList<>();
+        try {
+            for (Path p : paths) {
+                docs.add(PdfDocument.open(p));
+            }
+            return mergeWithBookmarks(docs);
+        } finally {
+            for (PdfDocument doc : docs) {
+                doc.close();
+            }
+        }
+    }
+
+    /**
+     * Depth-first flatten a single bookmark and its descendants into the builder,
+     * adding {@code pageOffset} to each internal destination. Returns whether at least
+     * one entry was actually added (i.e. the subtree had any GOTO targets).
+     */
+    private static boolean flattenInto(Bookmark bm, int pageOffset, BookmarkTree.Builder out) {
+        boolean added = false;
+        if (bm.isInternal()) {
+            out.add(bm.title(), bm.pageIndex() + pageOffset);
+            added = true;
+        }
+        for (Bookmark child : bm.children()) {
+            added |= flattenInto(child, pageOffset, out);
+        }
+        return added;
     }
 }

--- a/jpdfium/src/test/java/stirling/software/jpdfium/PdfMergeBookmarkTest.java
+++ b/jpdfium/src/test/java/stirling/software/jpdfium/PdfMergeBookmarkTest.java
@@ -1,0 +1,172 @@
+package stirling.software.jpdfium;
+
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.font.PDType1Font;
+import org.apache.pdfbox.pdmodel.font.Standard14Fonts;
+import org.apache.pdfbox.pdmodel.interactive.documentnavigation.outline.PDDocumentOutline;
+import org.apache.pdfbox.pdmodel.interactive.documentnavigation.outline.PDOutlineItem;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import stirling.software.jpdfium.doc.Bookmark;
+import stirling.software.jpdfium.panama.NativeLoader;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Verifies that {@link PdfMerge#mergeWithBookmarks} carries every input's bookmark tree
+ * into the merged output with page indices translated by the correct offset.
+ *
+ * <p>Compared to {@link PdfMerge#merge}, which uses PDFium's {@code FPDF_ImportPages} and
+ * drops outlines from inputs 2..N by design, the bookmark-preserving path walks each
+ * source's tree, flattens it depth-first, and writes a fresh outline on the merged doc.
+ */
+class PdfMergeBookmarkTest {
+
+    @BeforeAll
+    static void loadNative() {
+        NativeLoader.ensureLoaded();
+    }
+
+    @Test
+    void mergeWithBookmarksPreservesEntriesFromEveryInput(@TempDir File tmp) throws Exception {
+        Path a = createPdfWithOutline(
+                new File(tmp, "a.pdf").toPath(),
+                3,
+                "Doc A",
+                List.of(
+                        new OutlineEntry("Intro A", 0),
+                        new OutlineEntry("Setup A", 1)));
+        Path b = createPdfWithOutline(
+                new File(tmp, "b.pdf").toPath(),
+                4,
+                "Doc B",
+                List.of(
+                        new OutlineEntry("Body B", 0),
+                        new OutlineEntry("Detail B", 2),
+                        new OutlineEntry("Refs B", 3)));
+
+        byte[] mergedBytes = PdfMerge.mergeFilesWithBookmarks(List.of(a, b));
+        Path mergedPath = new File(tmp, "merged.pdf").toPath();
+        Files.write(mergedPath, mergedBytes);
+
+        try (PdfDocument merged = PdfDocument.open(mergedPath)) {
+            assertEquals(7, merged.pageCount(), "all pages from both inputs must survive");
+
+            List<Bookmark> outline = merged.bookmarks();
+            List<String> titles = flattenTitles(outline);
+
+            // First input's bookmarks: page indices unchanged
+            assertTrue(titles.contains("Intro A"),
+                    "missing 'Intro A' from first input — got: " + titles);
+            assertTrue(titles.contains("Setup A"),
+                    "missing 'Setup A' from first input — got: " + titles);
+
+            // Second input's bookmarks: page indices shifted by the first input's page count
+            assertTrue(titles.contains("Body B"),
+                    "missing 'Body B' from second input — got: " + titles);
+            assertTrue(titles.contains("Detail B"),
+                    "missing 'Detail B' from second input — got: " + titles);
+            assertTrue(titles.contains("Refs B"),
+                    "missing 'Refs B' from second input — got: " + titles);
+
+            Bookmark introA = findByTitle(outline, "Intro A").orElseThrow();
+            assertEquals(0, introA.pageIndex(),
+                    "first input's first bookmark should still target page 0");
+
+            // 'Body B' was at index 0 in input B; b.pdf starts at page 3 of the merged doc
+            // (after a.pdf's 3 pages), so its translated index must be 3.
+            Bookmark bodyB = findByTitle(outline, "Body B").orElseThrow();
+            assertEquals(3, bodyB.pageIndex(),
+                    "second input's first bookmark must be offset by first input's page count");
+
+            // 'Refs B' was at index 3 in input B; translated index is 3 + 3 = 6.
+            Bookmark refsB = findByTitle(outline, "Refs B").orElseThrow();
+            assertEquals(6, refsB.pageIndex(),
+                    "second input's last bookmark must be offset by first input's page count");
+        }
+    }
+
+    @Test
+    void mergeWithBookmarksReturnsBareMergeWhenNoSourceHasBookmarks(@TempDir File tmp)
+            throws Exception {
+        Path a = createPdfWithOutline(new File(tmp, "a.pdf").toPath(), 2, "A", List.of());
+        Path b = createPdfWithOutline(new File(tmp, "b.pdf").toPath(), 3, "B", List.of());
+
+        byte[] mergedBytes = PdfMerge.mergeFilesWithBookmarks(List.of(a, b));
+        Path mergedPath = new File(tmp, "merged.pdf").toPath();
+        Files.write(mergedPath, mergedBytes);
+
+        try (PdfDocument merged = PdfDocument.open(mergedPath)) {
+            assertEquals(5, merged.pageCount());
+            assertTrue(
+                    merged.bookmarks().isEmpty() || flattenTitles(merged.bookmarks()).isEmpty(),
+                    "no bookmarks expected when no source had any");
+        }
+    }
+
+    @Test
+    void mergeWithBookmarksRejectsEmptyList() {
+        assertThrows(IllegalArgumentException.class,
+                () -> PdfMerge.mergeWithBookmarks(List.of()));
+        assertThrows(IllegalArgumentException.class,
+                () -> PdfMerge.mergeFilesWithBookmarks(List.of()));
+    }
+
+    private static java.util.Optional<Bookmark> findByTitle(List<Bookmark> outline, String title) {
+        for (Bookmark bm : outline) {
+            if (title.equals(bm.title())) return java.util.Optional.of(bm);
+            var nested = findByTitle(bm.children(), title);
+            if (nested.isPresent()) return nested;
+        }
+        return java.util.Optional.empty();
+    }
+
+    private static List<String> flattenTitles(List<Bookmark> outline) {
+        List<String> titles = new ArrayList<>();
+        for (Bookmark bm : outline) {
+            if (bm.title() != null) titles.add(bm.title());
+            titles.addAll(flattenTitles(bm.children()));
+        }
+        return titles;
+    }
+
+    private record OutlineEntry(String title, int pageIndex) {}
+
+    private static Path createPdfWithOutline(
+            Path path, int pageCount, String docTitle, List<OutlineEntry> outline) throws Exception {
+        try (PDDocument doc = new PDDocument()) {
+            for (int i = 0; i < pageCount; i++) {
+                PDPage page = new PDPage();
+                doc.addPage(page);
+                try (PDPageContentStream cs = new PDPageContentStream(doc, page)) {
+                    cs.beginText();
+                    cs.setFont(new PDType1Font(Standard14Fonts.FontName.HELVETICA), 12);
+                    cs.newLineAtOffset(72, 720);
+                    cs.showText(docTitle + " page " + (i + 1));
+                    cs.endText();
+                }
+            }
+            if (!outline.isEmpty()) {
+                PDDocumentOutline pdOutline = new PDDocumentOutline();
+                doc.getDocumentCatalog().setDocumentOutline(pdOutline);
+                for (OutlineEntry e : outline) {
+                    PDOutlineItem item = new PDOutlineItem();
+                    item.setTitle(e.title());
+                    item.setDestination(doc.getPage(Math.min(e.pageIndex(), pageCount - 1)));
+                    pdOutline.addLast(item);
+                }
+            }
+            doc.save(path.toFile());
+        }
+        return path;
+    }
+}


### PR DESCRIPTION
## Summary
- `PdfMerge.merge` / `mergeFiles` use PDFium's `FPDF_ImportPages`, which copies pages but **not the outline tree**, so bookmarks from inputs 2..N are silently lost. This PR adds preservation paths without touching the existing fast-path API.
- New: `PdfMerge.mergeWithBookmarks(List<PdfDocument>)` and `mergeFilesWithBookmarks(List<Path>)` — walk every source's bookmark tree, translate page indices by the running offset of that source's pages in the merged output, and reconstruct the outline on the merged doc via `PdfBookmarkEditor.setBookmarks`.
- Existing `merge` and `mergeFiles` are unchanged — callers that don't want the extra qpdf round-trip keep the fast path.

## Why
PDFium's import API doesn't carry outline data. Two cases on the existing API:
- one input → bookmarks already survive (first doc is the catalog base)
- two or more inputs → only first input's outline survives; all others are dropped

For library users who care about bookmark-preserving merges (e.g. wrapping multiple chapter PDFs into one), today's `PdfMerge` is a regression vs PDFBox or pdfcpu. This PR closes that gap.

## Behaviour

| Property | `merge` (existing) | `mergeWithBookmarks` (new) |
|---|---|---|
| Pages | all preserved | all preserved |
| First input's `/Info` dict (Title/Author/Subject) | preserved | preserved (same catalog passthrough) |
| First input's outline | preserved | preserved |
| Outlines from inputs 2..N | **dropped** | **preserved, page indices translated** |
| External-target bookmarks (URI / LAUNCH / REMOTE_GOTO) | dropped | dropped (destinations don't translate) |
| Hierarchical outline trees | n/a | flattened depth-first (see "Limitations") |
| qpdf required at runtime | no | yes (inherited from `PdfBookmarkEditor.setBookmarks`) |
| Return type | `PdfDocument` | `byte[]` (matches `setBookmarks` return) |

## Limitations / follow-ups
- **Flat outline only.** `PdfBookmarkEditor`'s current writer (`appendOutlines`) emits a flat list (no `/First`/`/Last` subtrees per entry). The merge-bookmark path flattens the source trees by DFS to match that capacity. Lifting this is a separate change in `PdfBookmarkEditor` + `BookmarkEntry` to support a `children` list, after which the merge path can switch to nested.
- **GOTO actions only.** URI / LAUNCH / REMOTE_GOTO bookmarks are skipped — their destinations are external to the merged document. The `Bookmark.isInternal()` predicate gates inclusion.
- **No struct tree, form, or attachment merging.** Same as the existing `merge`; out of scope here.

## Test plan
- [x] `PdfMergeBookmarkTest.mergeWithBookmarksPreservesEntriesFromEveryInput` — generates two PDFBox PDFs (3-page + 4-page) each with their own outline, merges via `mergeFilesWithBookmarks`, asserts every source bookmark is present in the merged doc, and asserts page-index translation is correct: Intro A → 0 (first input), Body B → 3 (first input's 3 pages + 0), Refs B → 6 (first input's 3 pages + 3).
- [x] `PdfMergeBookmarkTest.mergeWithBookmarksReturnsBareMergeWhenNoSourceHasBookmarks` — skips the qpdf round-trip when there's nothing to transfer.
- [x] `PdfMergeBookmarkTest.mergeWithBookmarksRejectsEmptyList` — matches existing `merge` validation.