### PR TITLE
Add musl/Alpine native support (linux-musl-x64 / linux-musl-arm64)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,31 @@ jobs:
       - name: Compile main + test sources
         run: ./gradlew :jpdfium:compileJava :jpdfium:compileTestJava :jpdfium:processResources --no-daemon --stacktrace
 
+  # Validate NativeLoader picks linux-musl-* on a real musl system. Runs the
+  # loader on a JDK inside Alpine (no jextract/native needed — detectPlatform is
+  # pure logic), so PRs catch musl-detection regressions even though the musl
+  # PDFium native itself is built/proven separately in prebuild-pdfium.yml.
+  musl-detection:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: detectPlatform() must return linux-musl-* on Alpine
+        run: |
+          docker run --rm -i -v "$PWD":/src -w /src eclipse-temurin:25-jdk-alpine sh -s <<'INNER'
+          set -e
+          mkdir -p /tmp/m
+          javac -d /tmp/m \
+            jpdfium/src/main/java/stirling/software/jpdfium/panama/NativeLoader.java \
+            jpdfium/src/main/java/stirling/software/jpdfium/panama/Architecture.java \
+            jpdfium/src/main/java/stirling/software/jpdfium/exception/*.java
+          OUT=$(echo 'System.out.println(stirling.software.jpdfium.panama.NativeLoader.detectPlatform());' \
+            | jshell -q --class-path /tmp/m -)
+          echo "detectPlatform() on Alpine => $OUT"
+          echo "$OUT" | grep -q 'linux-musl-' || { echo "FAIL: expected linux-musl-*, got: $OUT"; exit 1; }
+          echo "OK: musl detection works"
+          INNER
+
   publish-dry-run:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/prebuild-pdfium.yml
+++ b/.github/workflows/prebuild-pdfium.yml
@@ -111,6 +111,16 @@ jobs:
           # how bblanchon/pdfium-binaries handles linux-arm64.
           - { platform: linux-arm64,  runner: ubuntu-latest,     target_cpu: arm64, mode: component }
           - { platform: linux-arm64,  runner: ubuntu-latest,     target_cpu: arm64, mode: static    }
+          # musl / Alpine (linux-musl-*). Built natively inside a matching-arch
+          # Alpine container so the system toolchain + libc are musl (no cross,
+          # no sysroot). PDFium/Chromium has no official musl support, so this is
+          # the CI-proving part and may need EmbedPDF fork patches — see the
+          # JPDFIUM_LIBC branch in setup-pdfium.sh. arm64 uses a native arm64
+          # runner to avoid musl cross-compile.
+          - { platform: linux-musl-x64,   runner: ubuntu-latest,    mode: component, libc: musl, container: 'alpine:3.21' }
+          - { platform: linux-musl-x64,   runner: ubuntu-latest,    mode: static,    libc: musl, container: 'alpine:3.21' }
+          - { platform: linux-musl-arm64, runner: ubuntu-24.04-arm, mode: component, libc: musl, container: 'alpine:3.21' }
+          - { platform: linux-musl-arm64, runner: ubuntu-24.04-arm, mode: static,    libc: musl, container: 'alpine:3.21' }
           # darwin-x64 cross-compiles from macos-14 (arm64) — the macos-13
           # free runner is constrained to the point of 24h queue timeouts.
           - { platform: darwin-x64,   runner: macos-14,          target_cpu: x64,   mode: component }
@@ -120,14 +130,26 @@ jobs:
           - { platform: windows-x64,  runner: windows-latest,    target_cpu: x64,   mode: component }
           - { platform: windows-x64,  runner: windows-latest,    target_cpu: x64,   mode: static    }
     runs-on: ${{ matrix.runner }}
+    # musl rows set matrix.container to an Alpine image; all others leave it unset
+    # (empty -> runs directly on the host runner).
+    container: ${{ matrix.container }}
     defaults:
       run:
         shell: bash
     steps:
+      # Alpine images have no bash/coreutils; bootstrap them (with sh) before any
+      # bash step runs. gcompat lets Chromium's glibc-built bundled clang run.
+      - name: Bootstrap Alpine (musl)
+        if: matrix.libc == 'musl'
+        shell: sh
+        run: |
+          apk add --no-cache bash build-base clang lld cmake ninja pkgconf \
+            python3 git curl tar xz gcompat libstdc++ linux-headers
+
       - uses: actions/checkout@v4
 
       - name: Install build deps (Linux)
-        if: startsWith(matrix.platform, 'linux-')
+        if: startsWith(matrix.platform, 'linux-') && matrix.libc != 'musl'
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential cmake ninja-build pkg-config python3 git
@@ -158,6 +180,7 @@ jobs:
           PINNED_SHA: ${{ needs.resolve-sha.outputs.sha }}
           TARGET_CPU: ${{ matrix.target_cpu }}
           JPDFIUM_BUILD_MODE: ${{ matrix.mode }}
+          JPDFIUM_LIBC: ${{ matrix.libc }}
         run: |
           # Override the branch pointer used by setup-pdfium.sh so every
           # matrix job builds the exact same commit even if embedpdf/main
@@ -198,7 +221,10 @@ jobs:
 
   release:
     needs: [resolve-sha, build]
-    if: inputs.dry-run != true && needs.resolve-sha.outputs.skip != 'true'
+    # always() so an unproven musl leg failing (matrix fail-fast is off) does not
+    # block the glibc/darwin/windows release. The sanity check below still hard-
+    # requires every non-musl platform; musl is warn-only until it goes green.
+    if: always() && inputs.dry-run != true && needs.resolve-sha.outputs.skip != 'true' && needs.resolve-sha.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -218,6 +244,12 @@ jobs:
           for p in linux-x64 linux-arm64 darwin-x64 darwin-arm64 windows-x64; do
             test -f ".prebuild/pdfium-$p.tar.gz"        || { echo "MISSING: $p (component)"; exit 1; }
             test -f ".prebuild/pdfium-$p-static.tar.gz" || { echo "MISSING: $p (static)";    exit 1; }
+          done
+          # musl is experimental — warn but don't block the release if the Alpine
+          # PDFium build is not green yet. Once it is, promote these to hard fails.
+          for p in linux-musl-x64 linux-musl-arm64; do
+            test -f ".prebuild/pdfium-$p.tar.gz"        || echo "WARNING: missing $p (component) — musl build not green yet";
+            test -f ".prebuild/pdfium-$p-static.tar.gz" || echo "WARNING: missing $p (static) — musl build not green yet";
           done
 
       - name: Create GitHub Release

--- a/.github/workflows/prebuild-pdfium.yml
+++ b/.github/workflows/prebuild-pdfium.yml
@@ -190,6 +190,19 @@ jobs:
           export JPDFIUM_BUILD_MODE="$JPDFIUM_BUILD_MODE"
           bash native/setup-pdfium.sh
 
+      # Real musl validation: the freshly-built PDFium must actually LOAD and RUN
+      # on Alpine/musl, not just compile. dlopen the .so and exercise the core
+      # FPDF API (init -> open a PDF -> page count). Component mode only (needs
+      # the shared lib). This is what proves musl support beyond the cheap
+      # detectPlatform() check in ci.yml.
+      - name: Smoke test musl PDFium (load + open a PDF)
+        if: matrix.libc == 'musl' && matrix.mode == 'component'
+        run: |
+          cc native/ci/pdfium_smoke.c -ldl -o /tmp/pdfium_smoke
+          LD_LIBRARY_PATH=native/pdfium/lib /tmp/pdfium_smoke \
+            native/pdfium/lib/libpdfium.so \
+            jpdfium/src/test/resources/pdfs/redact/redact-test-empty.pdf
+
       - name: Package artifacts
         # component mode keeps the historical tarball name
         # (`pdfium-<platform>.tar.gz`) for backward compatibility with the

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # ============================
 
 # Release version (override with -Pjpdfium.version=x.y.z)
-jpdfium.version=1.0.0-SNAPSHOT
+jpdfium.version=1.1.0-SNAPSHOT
 
 # Maven Central publishing (Central Portal — OSSRH Staging API)
 # OSSRH was sunset June 30 2025; publishing now goes via the Central Portal.

--- a/jpdfium-bom/build.gradle.kts
+++ b/jpdfium-bom/build.gradle.kts
@@ -10,6 +10,8 @@ dependencies {
         api(project(":jpdfium-spring"))
         api(project(":jpdfium-natives:jpdfium-natives-linux-x64"))
         api(project(":jpdfium-natives:jpdfium-natives-linux-arm64"))
+        api(project(":jpdfium-natives:jpdfium-natives-linux-musl-x64"))
+        api(project(":jpdfium-natives:jpdfium-natives-linux-musl-arm64"))
         api(project(":jpdfium-natives:jpdfium-natives-darwin-x64"))
         api(project(":jpdfium-natives:jpdfium-natives-darwin-arm64"))
         api(project(":jpdfium-natives:jpdfium-natives-windows-x64"))

--- a/jpdfium-natives/jpdfium-natives-linux-musl-arm64/build.gradle.kts
+++ b/jpdfium-natives/jpdfium-natives-linux-musl-arm64/build.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    id("jpdfium.natives-conventions")
+}

--- a/jpdfium-natives/jpdfium-natives-linux-musl-x64/build.gradle.kts
+++ b/jpdfium-natives/jpdfium-natives-linux-musl-x64/build.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    id("jpdfium.natives-conventions")
+}

--- a/jpdfium/src/main/java/stirling/software/jpdfium/panama/NativeLoader.java
+++ b/jpdfium/src/main/java/stirling/software/jpdfium/panama/NativeLoader.java
@@ -18,6 +18,7 @@ public final class NativeLoader {
 
     private static volatile boolean loaded = false;
     private static volatile Throwable loadError = null;
+    private static volatile Boolean muslLibc = null;
 
     private NativeLoader() {}
 
@@ -176,8 +177,49 @@ public final class NativeLoader {
 
     public static String detectPlatform() {
         String os = System.getProperty("os.name").toLowerCase();
-        String osKey = os.contains("win") ? "windows" : os.contains("mac") ? "darwin" : "linux";
-        return osKey + "-" + Architecture.detect().key();
+        if (os.contains("win")) return "windows-" + Architecture.detect().key();
+        if (os.contains("mac")) return "darwin-" + Architecture.detect().key();
+        // Linux natives are libc-specific: musl (Alpine) cannot load glibc binaries.
+        String libc = isMuslLibc() ? "musl-" : "";
+        return "linux-" + libc + Architecture.detect().key();
+    }
+
+    static boolean isMuslLibc() {
+        Boolean cached = muslLibc;
+        if (cached != null) return cached;
+        boolean result = detectMuslLibc();
+        muslLibc = result;
+        return result;
+    }
+
+    private static boolean detectMuslLibc() {
+        // Primary signal: musl ships its loader as /lib/ld-musl-<arch>.so.1.
+        try (var dir = Files.newDirectoryStream(Path.of("/lib"), "ld-musl-*")) {
+            if (dir.iterator().hasNext()) return true;
+        } catch (IOException | RuntimeException ignored) {
+            // /lib missing or unreadable; fall through to the ldd probe
+        }
+        // Fallback: `ldd --version` reports "musl" on Alpine, "glibc" elsewhere.
+        try {
+            Process p = new ProcessBuilder("ldd", "--version")
+                    .redirectErrorStream(true).start();
+            try (BufferedReader r = new BufferedReader(
+                    new InputStreamReader(p.getInputStream(), StandardCharsets.UTF_8))) {
+                String line;
+                while ((line = r.readLine()) != null) {
+                    if (line.toLowerCase().contains("musl")) {
+                        p.waitFor();
+                        return true;
+                    }
+                }
+            }
+            p.waitFor();
+        } catch (IOException ignored) {
+            // ldd absent; assume glibc
+        } catch (InterruptedException ignored) {
+            Thread.currentThread().interrupt();
+        }
+        return false;
     }
 
     static String nativeFilename(String lib) {

--- a/jpdfium/src/test/java/stirling/software/jpdfium/panama/NativeLoaderPlatformTest.java
+++ b/jpdfium/src/test/java/stirling/software/jpdfium/panama/NativeLoaderPlatformTest.java
@@ -1,0 +1,50 @@
+package stirling.software.jpdfium.panama;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pure-logic tests for platform detection (no native load), so they run on every
+ * host without the PDFium native present. Guards the linux-musl-* selection used
+ * to pick libc-specific natives on Alpine.
+ */
+class NativeLoaderPlatformTest {
+
+    @Test
+    void detectPlatformReturnsKnownKey() {
+        String p = NativeLoader.detectPlatform();
+        assertTrue(
+                p.matches("(linux(-musl)?|darwin|windows)-(x64|arm64)"),
+                "unexpected platform key: " + p);
+    }
+
+    @Test
+    void linuxMuslSuffixMatchesHostLibc() throws Exception {
+        String p = NativeLoader.detectPlatform();
+        if (!p.startsWith("linux-")) {
+            return; // libc distinction only applies to Linux
+        }
+        // On a musl host (Alpine) the key must carry the -musl- segment; on glibc
+        // it must not. Catches accidental removal of the musl branch.
+        assertEquals(
+                hostHasMuslLoader(),
+                p.contains("-musl-"),
+                "platform musl suffix should match host libc: " + p);
+    }
+
+    private static boolean hostHasMuslLoader() throws Exception {
+        Path lib = Path.of("/lib");
+        if (!Files.isDirectory(lib)) {
+            return false;
+        }
+        try (DirectoryStream<Path> d = Files.newDirectoryStream(lib, "ld-musl-*")) {
+            return d.iterator().hasNext();
+        }
+    }
+}

--- a/native/ci/pdfium_smoke.c
+++ b/native/ci/pdfium_smoke.c
@@ -1,0 +1,54 @@
+// Minimal, header-free smoke test for a built PDFium shared library.
+// dlopen()s libpdfium by path (resolving sibling component libs via its
+// RUNPATH=$ORIGIN, exactly like the JVM's System.load) and exercises the core
+// FPDF API: init -> open a PDF -> page count -> close. Proves the native both
+// LOADS and RUNS on the host libc (the real value on musl/Alpine, where a
+// glibc-built PDFium would not even load).
+//
+// Usage: pdfium_smoke <path/to/libpdfium.so> <path/to/test.pdf>
+// Exit:  0 ok, 2 load/symbol error, 3 document load failed, 4 unexpected pages.
+#include <stdio.h>
+#include <dlfcn.h>
+
+typedef void  (*init_fn)(void);
+typedef void *(*load_fn)(const char *path, const char *password);
+typedef int   (*pagecount_fn)(void *doc);
+typedef void  (*close_fn)(void *doc);
+typedef void  (*destroy_fn)(void);
+
+int main(int argc, char **argv) {
+    if (argc != 3) {
+        fprintf(stderr, "usage: %s <libpdfium.so> <test.pdf>\n", argv[0]);
+        return 2;
+    }
+
+    void *h = dlopen(argv[1], RTLD_NOW | RTLD_GLOBAL);
+    if (!h) {
+        fprintf(stderr, "dlopen failed: %s\n", dlerror());
+        return 2;
+    }
+
+    init_fn      FPDF_InitLibrary   = (init_fn)      dlsym(h, "FPDF_InitLibrary");
+    load_fn      FPDF_LoadDocument  = (load_fn)      dlsym(h, "FPDF_LoadDocument");
+    pagecount_fn FPDF_GetPageCount  = (pagecount_fn) dlsym(h, "FPDF_GetPageCount");
+    close_fn     FPDF_CloseDocument = (close_fn)     dlsym(h, "FPDF_CloseDocument");
+    destroy_fn   FPDF_DestroyLibrary= (destroy_fn)   dlsym(h, "FPDF_DestroyLibrary");
+    if (!FPDF_InitLibrary || !FPDF_LoadDocument || !FPDF_GetPageCount
+            || !FPDF_CloseDocument || !FPDF_DestroyLibrary) {
+        fprintf(stderr, "dlsym failed: missing FPDF symbol\n");
+        return 2;
+    }
+
+    FPDF_InitLibrary();
+    void *doc = FPDF_LoadDocument(argv[2], NULL);
+    if (!doc) {
+        fprintf(stderr, "FPDF_LoadDocument failed for %s\n", argv[2]);
+        FPDF_DestroyLibrary();
+        return 3;
+    }
+    int pages = FPDF_GetPageCount(doc);
+    printf("pages=%d\n", pages);
+    FPDF_CloseDocument(doc);
+    FPDF_DestroyLibrary();
+    return pages >= 1 ? 0 : 4;
+}

--- a/native/fetch-prebuilt-pdfium.sh
+++ b/native/fetch-prebuilt-pdfium.sh
@@ -9,7 +9,8 @@
 # Usage:
 #   native/fetch-prebuilt-pdfium.sh <platform>
 #
-# Where <platform> is one of: linux-x64, linux-arm64, darwin-x64, darwin-arm64, windows-x64.
+# Where <platform> is one of: linux-x64, linux-arm64, linux-musl-x64,
+# linux-musl-arm64, darwin-x64, darwin-arm64, windows-x64.
 #
 # Requires:
 #   - gh CLI authenticated (GH_TOKEN env var is enough in GitHub Actions)
@@ -19,7 +20,7 @@ set -euo pipefail
 PLATFORM="${1:-}"
 if [ -z "$PLATFORM" ]; then
     echo "Usage: $0 <platform>" >&2
-    echo "  platform: linux-x64 | linux-arm64 | darwin-x64 | darwin-arm64 | windows-x64" >&2
+    echo "  platform: linux-x64 | linux-arm64 | linux-musl-x64 | linux-musl-arm64 | darwin-x64 | darwin-arm64 | windows-x64" >&2
     exit 2
 fi
 

--- a/native/setup-pdfium.sh
+++ b/native/setup-pdfium.sh
@@ -404,6 +404,20 @@ if [ "$(uname -s)" = "Linux" ] && [ "${TARGET_CPU:-}" = "arm64" ]; then
     fi
 fi
 
+# musl / Alpine target. Set JPDFIUM_LIBC=musl (the linux-musl-* prebuild rows
+# run inside an Alpine container so the system toolchain + libc are musl).
+# PDFium/Chromium has no official musl support, so this is the CI-proving part:
+#   - Chromium's bundled clang is a glibc binary; in Alpine it needs `apk add
+#     gcompat` to run, or the build must point at Alpine's system clang.
+#   - use_custom_libcxx=true: Alpine ships libstdc++, not libc++, so let Chromium
+#     build/export its own libc++ (same reasoning as the Windows branch below).
+#   - use_sysroot=false: link against the container's musl system libraries.
+# Expect EmbedPDF fork patches may be needed; iterate via the Prebuild PDFium CI.
+if [ "${JPDFIUM_LIBC:-}" = "musl" ]; then
+    GN_ARGS="${GN_ARGS/use_custom_libcxx=false/use_custom_libcxx=true}"
+    echo "  musl/Alpine target: use_custom_libcxx=true, use_sysroot=false"
+fi
+
 # Windows has no system libc++, so use_custom_libcxx=false produces broken
 # component builds — abseil-cpp.dll fails to link with undefined symbols on
 # std::__Cr::basic_string template instantiations because the libc++ DLL

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,6 +6,8 @@ include(
     "jpdfium-spring",
     "jpdfium-natives:jpdfium-natives-linux-x64",
     "jpdfium-natives:jpdfium-natives-linux-arm64",
+    "jpdfium-natives:jpdfium-natives-linux-musl-x64",
+    "jpdfium-natives:jpdfium-natives-linux-musl-arm64",
     "jpdfium-natives:jpdfium-natives-darwin-x64",
     "jpdfium-natives:jpdfium-natives-darwin-arm64",
     "jpdfium-natives:jpdfium-natives-windows-x64"


### PR DESCRIPTION
## Summary

Adds `linux-musl-x64` and `linux-musl-arm64` native targets so JPDFium can run on Alpine/musl (e.g. Stirling-PDF's ultra-lite Docker image). The bundled PDFium natives are glibc-linked today, so a musl JVM can't load them; this wires up musl-specific native artifacts and runtime selection.

## What's in here

**Validated locally (gradle wiring resolves, `:jpdfium:compileJava` is green):**
- `NativeLoader.detectPlatform()` now detects musl (probes `/lib/ld-musl-*`, falls back to `ldd --version`) and returns `linux-musl-<arch>`, cached.
- New gradle modules `jpdfium-natives-linux-musl-x64` / `-arm64` (use the existing platform-generic `natives-conventions` plugin), wired into `settings.gradle.kts` and the BOM.
- `jpdfium.version` bumped to `1.1.0-SNAPSHOT`.
- `fetch-prebuilt-pdfium.sh` doc/usage updated for the new platforms (no whitelist to change).

**Best-effort, must be proven by CI (I cannot build Chromium-under-musl locally):**
- `prebuild-pdfium.yml`: new `linux-musl-*` matrix legs that build natively inside matching-arch Alpine containers (x64 on `ubuntu-latest`, arm64 on `ubuntu-24.04-arm`), with a bash/toolchain bootstrap (`apk add ... gcompat`). The release job is now `always()` + warn-only for musl so an unproven musl leg can't block the glibc/darwin/windows prebuild.
- `setup-pdfium.sh`: a `JPDFIUM_LIBC=musl` branch (`use_custom_libcxx=true`).

## Honest caveat / how to test

PDFium/Chromium has **no official musl support** and its bundled clang is a glibc binary, so the Alpine PDFium build is the open part - it will likely need EmbedPDF fork patches and GN/toolchain tuning. Note `prebuild-pdfium.yml` runs on `workflow_dispatch`/cron, **not** on PRs, so to actually exercise the musl legs trigger the **Prebuild PDFium** workflow manually on this branch. The publish workflows (release/snapshot/publish-github-packages) are intentionally **not** wired for musl yet - that's a follow-up once the musl prebuild is green (no point publishing natives that don't build).

Opening as a draft to see how the musl prebuild fares in CI.
