### PR TITLE
Functionally smoke-test each native in CI (load + open a PDF)

### DIFF
--- a/.github/workflows/publish-github-packages.yml
+++ b/.github/workflows/publish-github-packages.yml
@@ -185,6 +185,28 @@ jobs:
             exit 1
           }
 
+      # Beyond "a file exists": load the freshly-built native via the production
+      # NativeLoader and open a PDF. Skipped for darwin-x64 (cross-compiled on an
+      # arm64 host, so the x64 native can't run here); other platforms build on
+      # their own arch.
+      - name: Install jextract (for smoke build)
+        if: matrix.platform != 'darwin-x64'
+        shell: bash
+        run: |
+          case "$RUNNER_OS" in
+            Linux)   JX=openjdk-25-jextract+2-4_linux-x64_bin.tar.gz ;;
+            macOS)   if [ "$(uname -m)" = arm64 ]; then JX=openjdk-25-jextract+2-4_macos-aarch64_bin.tar.gz; else JX=openjdk-25-jextract+2-4_macos-x64_bin.tar.gz; fi ;;
+            Windows) JX=openjdk-25-jextract+2-4_windows-x64_bin.tar.gz ;;
+          esac
+          mkdir -p "$HOME/jextract-install"
+          curl -fsSL "https://download.java.net/java/early_access/jextract/25/2/$JX" -o /tmp/jx.tar.gz
+          tar -xzf /tmp/jx.tar.gz -C "$HOME/jextract-install" --strip-components=1
+          echo "JEXTRACT_HOME=$HOME/jextract-install" >> "$GITHUB_ENV"
+
+      - name: Functional smoke test (load native + open a PDF)
+        if: matrix.platform != 'darwin-x64'
+        run: ./gradlew :jpdfium:nativeSmokeTest -Pjpdfium.testNatives=${{ matrix.platform }} --no-daemon --stacktrace
+
       - uses: actions/upload-artifact@v4
         with:
           name: natives-${{ matrix.platform }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -279,10 +279,12 @@ jobs:
 
       # Functionally verify the freshly-built native instead of trusting that a
       # file was produced: load it via the production NativeLoader and open a
-      # PDF. Skipped for darwin-x64 (cross-compiled on an arm64 host, so the x64
-      # native can't run here); every other platform builds on its own arch.
+      # PDF. Skips: darwin-x64 (cross-compiled on an arm64 host, can't run here),
+      # and all darwin on PRs (macOS rejects the unsigned dylib — signing only
+      # runs on push/release). Linux + Windows don't need signing, so they smoke
+      # on every PR.
       - name: Install jextract (for smoke build)
-        if: matrix.platform != 'darwin-x64'
+        if: matrix.platform != 'darwin-x64' && (github.event_name != 'pull_request' || !startsWith(matrix.platform, 'darwin-'))
         shell: bash
         run: |
           case "$RUNNER_OS" in
@@ -296,7 +298,7 @@ jobs:
           echo "JEXTRACT_HOME=$HOME/jextract-install" >> "$GITHUB_ENV"
 
       - name: Functional smoke test (load native + open a PDF)
-        if: matrix.platform != 'darwin-x64'
+        if: matrix.platform != 'darwin-x64' && (github.event_name != 'pull_request' || !startsWith(matrix.platform, 'darwin-'))
         run: ./gradlew :jpdfium:nativeSmokeTest -Pjpdfium.testNatives=${{ matrix.platform }} --no-daemon --stacktrace
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -271,6 +271,28 @@ jobs:
           bash native/bundle-runtime-deps.sh ${{ matrix.platform }}
           ls -la native/dist/${{ matrix.platform }}/
 
+      # Functionally verify the freshly-built native instead of trusting that a
+      # file was produced: load it via the production NativeLoader and open a
+      # PDF. Skipped for darwin-x64 (cross-compiled on an arm64 host, so the x64
+      # native can't run here); every other platform builds on its own arch.
+      - name: Install jextract (for smoke build)
+        if: matrix.platform != 'darwin-x64'
+        shell: bash
+        run: |
+          case "$RUNNER_OS" in
+            Linux)   JX=openjdk-25-jextract+2-4_linux-x64_bin.tar.gz ;;
+            macOS)   if [ "$(uname -m)" = arm64 ]; then JX=openjdk-25-jextract+2-4_macos-aarch64_bin.tar.gz; else JX=openjdk-25-jextract+2-4_macos-x64_bin.tar.gz; fi ;;
+            Windows) JX=openjdk-25-jextract+2-4_windows-x64_bin.tar.gz ;;
+          esac
+          mkdir -p "$HOME/jextract-install"
+          curl -fsSL "https://download.java.net/java/early_access/jextract/25/2/$JX" -o /tmp/jx.tar.gz
+          tar -xzf /tmp/jx.tar.gz -C "$HOME/jextract-install" --strip-components=1
+          echo "JEXTRACT_HOME=$HOME/jextract-install" >> "$GITHUB_ENV"
+
+      - name: Functional smoke test (load native + open a PDF)
+        if: matrix.platform != 'darwin-x64'
+        run: ./gradlew :jpdfium:nativeSmokeTest -Pjpdfium.testNatives=${{ matrix.platform }} --no-daemon --stacktrace
+
       - uses: actions/upload-artifact@v4
         with:
           name: natives-${{ matrix.platform }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -3,6 +3,10 @@ name: Snapshot to Central Portal
 on:
   push:
     branches: [main, publishing-setup]   # publishing-setup temporary, for bring-up testing
+  # On PRs we build the real natives per platform and run the functional smoke
+  # (load + open a PDF), but never publish — so every PR is verified against the
+  # actual artifact, not just a compile.
+  pull_request: {}
   workflow_dispatch:
     inputs:
       build_mode:
@@ -223,7 +227,9 @@ jobs:
         run: bash native/build-minimal-icu-macos.sh
 
       - name: Import macOS signing certificate
-        if: startsWith(matrix.platform, 'darwin-')
+        # Signing is a publish concern; skip on PRs (the smoke loads the
+        # freshly-built unsigned dylib on the same runner just fine).
+        if: startsWith(matrix.platform, 'darwin-') && github.event_name != 'pull_request'
         env:
           MACOS_CERTIFICATE_P12_BASE64: ${{ secrets.MACOS_CERTIFICATE_P12_BASE64 }}
           MACOS_CERTIFICATE_PASSWORD: ${{ secrets.MACOS_CERTIFICATE_PASSWORD }}
@@ -302,9 +308,9 @@ jobs:
 
   publish-snapshot:
     needs: build-natives
-    # Skipped on a dry run (workflow_dispatch with skip_publish=true) so the
-    # build+sign job can be exercised without shipping a snapshot publicly.
-    if: ${{ inputs.skip_publish != true }}
+    # Skipped on a dry run (workflow_dispatch with skip_publish=true) and never
+    # runs on pull_request — PRs build + smoke-test the natives but must not ship.
+    if: ${{ inputs.skip_publish != true && github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/jpdfium/build.gradle.kts
+++ b/jpdfium/build.gradle.kts
@@ -5,7 +5,11 @@ plugins {
 dependencies {
     implementation(libs.imageio.webp)
     implementation(libs.imageio.tiff)
-    testRuntimeOnly(project(":jpdfium-natives:jpdfium-natives-linux-x64"))
+    // Which platform's native jar lands on the test classpath. Defaults to
+    // linux-x64 for local dev; CI overrides per matrix job with
+    // -Pjpdfium.testNatives=<platform> so the smoke loads the native it built.
+    val testNatives = (findProperty("jpdfium.testNatives") ?: "linux-x64").toString()
+    testRuntimeOnly(project(":jpdfium-natives:jpdfium-natives-$testNatives"))
     testImplementation(libs.pdfbox)
 }
 
@@ -174,4 +178,19 @@ tasks.register<Test>("integrationTest") {
     }
     jvmArgs("--enable-native-access=ALL-UNNAMED")
     maxHeapSize = System.getProperty("jpdfium.bench.xmx", "2g")
+}
+
+// Run: ./gradlew :jpdfium:nativeSmokeTest -Pjpdfium.testNatives=<platform>
+// Fast per-platform functional check: load the bundled native via the
+// production NativeLoader path and open a PDF. Used by CI to verify each
+// freshly-built native actually runs (not just that a file was produced).
+tasks.register<Test>("nativeSmokeTest") {
+    group       = "verification"
+    description = "Load the bundled native and open a PDF (per-platform CI smoke)"
+    useJUnitPlatform()
+    testClassesDirs = sourceSets.test.get().output.classesDirs
+    classpath       = sourceSets.test.get().runtimeClasspath
+    systemProperty("jpdfium.smoke", "true")
+    filter { includeTestsMatching("*NativeSmokeTest") }
+    jvmArgs("--enable-native-access=ALL-UNNAMED")
 }

--- a/jpdfium/src/test/java/stirling/software/jpdfium/NativeSmokeTest.java
+++ b/jpdfium/src/test/java/stirling/software/jpdfium/NativeSmokeTest.java
@@ -1,0 +1,36 @@
+package stirling.software.jpdfium;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Functional smoke test for the bundled native: loads it through the production
+ * {@code NativeLoader} path and opens a real PDF. Gated on -Djpdfium.smoke=true
+ * so it only runs in the per-platform CI jobs (where a matching native is on the
+ * classpath), not in the stub/compile-only PR build. This is what proves a
+ * freshly-built native actually loads and runs, replacing a "file exists" check.
+ */
+@EnabledIfSystemProperty(named = "jpdfium.smoke", matches = "true")
+class NativeSmokeTest {
+
+    @Test
+    void loadsNativeAndOpensPdf(@TempDir Path tmp) throws Exception {
+        Path pdf = tmp.resolve("smoke.pdf");
+        try (InputStream in =
+                getClass().getResourceAsStream("/pdfs/redact/redact-test-empty.pdf")) {
+            assertNotNull(in, "smoke fixture must be on the test classpath");
+            Files.copy(in, pdf);
+        }
+        try (PdfDocument doc = PdfDocument.open(pdf)) {
+            assertTrue(doc.pageCount() >= 1, "native should report >= 1 page");
+        }
+    }
+}


### PR DESCRIPTION
## Problem

The natives are never functionally tested in CI. Per-platform jobs in `snapshot.yml` / `publish-github-packages.yml` build the real bridge and then only check the output dir is non-empty (`test -n "$(ls -A native/dist/...)"`); `ci.yml` builds a *stub* and compile-checks. The real integration tests are gated behind `-Djpdfium.integration=true` and never run in CI. So a native that builds but can't load (missing dep, bad libc, ABI break) ships green.

## Change

Functionally smoke-test each freshly-built native through the **production load path**:

- **`NativeSmokeTest`** - loads the native via `NativeLoader` and opens a real PDF (`PdfDocument.open` → `pageCount() >= 1`). Gated on `-Djpdfium.smoke=true` so it only runs where a matching native is present (not in the stub PR build).
- **`nativeSmokeTest` gradle task** + a platform-selectable test native: `testRuntimeOnly` now honors `-Pjpdfium.testNatives=<platform>` (default `linux-x64`), so each CI job loads the native it just built instead of always linux-x64.
- **`snapshot.yml` + `publish-github-packages.yml`**: after bundling, install jextract and run `:jpdfium:nativeSmokeTest -Pjpdfium.testNatives=<platform>`. Covers linux-x64, linux-arm64, darwin-arm64, windows-x64. `darwin-x64` is skipped (cross-compiled on an arm64 host, so the x64 native can't execute there) and keeps the file-exists check.

## Validation

Ran the new task locally on a real host (Windows x64), staging the published windows native into `native/dist/windows-x64/`:

```
> Task :jpdfium:nativeSmokeTest
tests="1" skipped="0" failures="0" errors="0"
loadsNativeAndOpensPdf  PASSED (0.89s)
```

So the production load path + PDF open is exercised, not just "a file exists". The other platforms run the same task on their own native runner in CI.

Note: this is independent of the musl PR (#16); once both land, musl gets the same smoke for free via `-Pjpdfium.testNatives=linux-musl-*`.
