### PR TITLE
Serialise all PDFium native calls to fix concurrent-use crashes

### DIFF
--- a/jpdfium/src/main/java/stirling/software/jpdfium/PdfDocument.java
+++ b/jpdfium/src/main/java/stirling/software/jpdfium/PdfDocument.java
@@ -15,12 +15,18 @@ import java.util.Optional;
  *
  * <p><strong>Thread safety:</strong> A single {@code PdfDocument} instance (and any
  * {@link PdfPage} handles obtained from it) must be confined to one thread at a time.
- * Multiple independent {@code PdfDocument} instances on separate threads are safe.
+ *
+ * <p>Independent {@code PdfDocument} instances may be used from separate threads:
+ * PDFium itself is not thread-safe even across independent documents, so every
+ * native call is serialised by {@link stirling.software.jpdfium.panama.NativeGuard}.
+ * That makes concurrent use safe, but PDFium work does not run in parallel - the
+ * throughput ceiling is roughly one thread's worth of PDFium time.
  */
 public final class PdfDocument implements AutoCloseable {
 
     private final long handle;
-    private volatile boolean closed = false;
+    private final java.util.concurrent.atomic.AtomicBoolean closed =
+            new java.util.concurrent.atomic.AtomicBoolean();
 
     PdfDocument(long handle) {
         this.handle = handle;
@@ -227,13 +233,14 @@ public final class PdfDocument implements AutoCloseable {
     }
 
     private void ensureOpen() {
-        if (closed) throw new IllegalStateException("PdfDocument is already closed");
+        if (closed.get()) throw new IllegalStateException("PdfDocument is already closed");
     }
 
     @Override
     public void close() {
-        if (closed) return;
-        closed = true;
+        // compareAndSet, not check-then-set: a lost race here frees the same
+        // native document twice and corrupts the heap.
+        if (!closed.compareAndSet(false, true)) return;
         JpdfiumLib.docClose(handle);
     }
 }

--- a/jpdfium/src/main/java/stirling/software/jpdfium/PdfPage.java
+++ b/jpdfium/src/main/java/stirling/software/jpdfium/PdfPage.java
@@ -20,7 +20,8 @@ import java.util.Optional;
 public final class PdfPage implements AutoCloseable {
 
     private final long handle;
-    private volatile boolean closed = false;
+    private final java.util.concurrent.atomic.AtomicBoolean closed =
+            new java.util.concurrent.atomic.AtomicBoolean();
 
     private PdfPage(long handle) {
         this.handle = handle;
@@ -305,13 +306,14 @@ public final class PdfPage implements AutoCloseable {
     }
 
     private void ensureOpen() {
-        if (closed) throw new IllegalStateException("PdfPage is already closed");
+        if (closed.get()) throw new IllegalStateException("PdfPage is already closed");
     }
 
     @Override
     public void close() {
-        if (closed) return;
-        closed = true;
+        // compareAndSet, not check-then-set: a lost race here closes the same
+        // native page twice and corrupts the heap.
+        if (!closed.compareAndSet(false, true)) return;
         JpdfiumLib.pageClose(handle);
     }
 }

--- a/jpdfium/src/main/java/stirling/software/jpdfium/PdfPipeline.java
+++ b/jpdfium/src/main/java/stirling/software/jpdfium/PdfPipeline.java
@@ -33,8 +33,10 @@ import java.util.function.BiConsumer;
  * <h3>Thread Safety &amp; PDFium</h3>
  * <p>PDFium's internal state (font renderer, document loader, page parser) is
  * <b>not thread-safe</b> - even across independent document instances. All
- * PDFium native calls must be serialized. The pipeline handles this via
- * {@link #PDFIUM_LOCK}.
+ * PDFium native calls must be serialized. Since 1.0.4 the library does this
+ * for you: every native call goes through
+ * {@link stirling.software.jpdfium.panama.NativeGuard}, so no caller-side
+ * locking is required anywhere.
  *
  * <p>Parallel speedup comes from overlapping Java-side work (hashing, NLP,
  * image processing, I/O) across threads while PDFium calls are pipelined
@@ -85,14 +87,14 @@ public final class PdfPipeline {
      * (font renderer, document loader, page parser) is <b>not thread-safe</b>
      * - even across independent document instances.
      *
-     * <p>In parallel mode, wrap all PDFium calls (page open/close, text
-     * extraction, rendering, annotation CRUD) with
-     * {@code synchronized(PdfPipeline.PDFIUM_LOCK)}. Java-side processing
-     * between PDFium calls runs in parallel without the lock.
-     *
-     * <p>In sequential and streaming modes, the lock is unnecessary because
-     * only one thread accesses PDFium.
+     * @deprecated since 1.0.4 - callers no longer need this. Every native call
+     *     is serialised internally by
+     *     {@link stirling.software.jpdfium.panama.NativeGuard}, so PDFium calls
+     *     are safe from any thread without caller-side locking. The field is
+     *     retained so existing {@code synchronized(PDFIUM_LOCK)} blocks keep
+     *     compiling; they are now redundant but harmless.
      */
+    @Deprecated(since = "1.0.4")
     public static final Object PDFIUM_LOCK = new Object();
 
     /**

--- a/jpdfium/src/main/java/stirling/software/jpdfium/doc/PdfPageImporter.java
+++ b/jpdfium/src/main/java/stirling/software/jpdfium/doc/PdfPageImporter.java
@@ -1,5 +1,6 @@
 package stirling.software.jpdfium.doc;
 
+import stirling.software.jpdfium.panama.NativeGuard;
 import stirling.software.jpdfium.panama.JpdfiumH;
 import stirling.software.jpdfium.panama.PageImportBindings;
 
@@ -42,22 +43,27 @@ public final class PdfPageImporter {
      */
     public static boolean importPages(MemorySegment dest, MemorySegment src,
                                        String pageRange, int insertAt) {
-        try (Arena arena = Arena.ofConfined()) {
-            MemorySegment rangeStr;
-            if (pageRange != null) {
-                byte[] bytes = pageRange.getBytes(StandardCharsets.US_ASCII);
-                rangeStr = arena.allocate(bytes.length + 1L);
-                rangeStr.copyFrom(MemorySegment.ofArray(bytes));
-                rangeStr.set(ValueLayout.JAVA_BYTE, bytes.length, (byte) 0);
-            } else {
-                rangeStr = MemorySegment.NULL;
-            }
+        NativeGuard.acquire();
+        try {
+            try (Arena arena = Arena.ofConfined()) {
+                MemorySegment rangeStr;
+                if (pageRange != null) {
+                    byte[] bytes = pageRange.getBytes(StandardCharsets.US_ASCII);
+                    rangeStr = arena.allocate(bytes.length + 1L);
+                    rangeStr.copyFrom(MemorySegment.ofArray(bytes));
+                    rangeStr.set(ValueLayout.JAVA_BYTE, bytes.length, (byte) 0);
+                } else {
+                    rangeStr = MemorySegment.NULL;
+                }
 
-            int ok;
-            try {
-                ok = (int) PageImportBindings.FPDF_ImportPages.invokeExact(dest, src, rangeStr, insertAt);
-            } catch (Throwable t) { throw new RuntimeException("FPDF_ImportPages failed", t); }
-            return ok != 0;
+                int ok;
+                try {
+                    ok = (int) PageImportBindings.FPDF_ImportPages.invokeExact(dest, src, rangeStr, insertAt);
+                } catch (Throwable t) { throw new RuntimeException("FPDF_ImportPages failed", t); }
+                return ok != 0;
+            }
+        } finally {
+            NativeGuard.release();
         }
     }
 
@@ -72,19 +78,24 @@ public final class PdfPageImporter {
      */
     public static boolean importPagesByIndex(MemorySegment dest, MemorySegment src,
                                               int[] pageIndices, int insertAt) {
-        try (Arena arena = Arena.ofConfined()) {
-            MemorySegment indices = arena.allocate(
-                    ValueLayout.JAVA_INT, pageIndices.length);
-            for (int i = 0; i < pageIndices.length; i++) {
-                indices.setAtIndex(ValueLayout.JAVA_INT, i, pageIndices[i]);
-            }
+        NativeGuard.acquire();
+        try {
+            try (Arena arena = Arena.ofConfined()) {
+                MemorySegment indices = arena.allocate(
+                        ValueLayout.JAVA_INT, pageIndices.length);
+                for (int i = 0; i < pageIndices.length; i++) {
+                    indices.setAtIndex(ValueLayout.JAVA_INT, i, pageIndices[i]);
+                }
 
-            int ok;
-            try {
-                ok = (int) PageImportBindings.FPDF_ImportPagesByIndex.invokeExact(dest, src,
-                        indices, (long) pageIndices.length, insertAt);
-            } catch (Throwable t) { throw new RuntimeException("FPDF_ImportPagesByIndex failed", t); }
-            return ok != 0;
+                int ok;
+                try {
+                    ok = (int) PageImportBindings.FPDF_ImportPagesByIndex.invokeExact(dest, src,
+                            indices, (long) pageIndices.length, insertAt);
+                } catch (Throwable t) { throw new RuntimeException("FPDF_ImportPagesByIndex failed", t); }
+                return ok != 0;
+            }
+        } finally {
+            NativeGuard.release();
         }
     }
 
@@ -96,10 +107,15 @@ public final class PdfPageImporter {
      * @return true if copy succeeded
      */
     public static boolean copyViewerPreferences(MemorySegment dest, MemorySegment src) {
+        NativeGuard.acquire();
         try {
-            int ok = (int) PageImportBindings.FPDF_CopyViewerPreferences.invokeExact(dest, src);
-            return ok != 0;
-        } catch (Throwable t) { throw new RuntimeException("FPDF_CopyViewerPreferences failed", t); }
+            try {
+                int ok = (int) PageImportBindings.FPDF_CopyViewerPreferences.invokeExact(dest, src);
+                return ok != 0;
+            } catch (Throwable t) { throw new RuntimeException("FPDF_CopyViewerPreferences failed", t); }
+        } finally {
+            NativeGuard.release();
+        }
     }
 
     /**
@@ -118,16 +134,21 @@ public final class PdfPageImporter {
     public static byte[] importNPagesToOne(MemorySegment srcDoc,
                                             float outputWidth, float outputHeight,
                                             int cols, int rows) {
-        try (Arena arena = Arena.ofConfined()) {
-            MemorySegment ptrSeg = arena.allocate(ADDRESS);
-            MemorySegment lenSeg = arena.allocate(JAVA_LONG);
-            int rc = JpdfiumH.jpdfium_import_n_pages_to_one(
-                    srcDoc, outputWidth, outputHeight, cols, rows, ptrSeg, lenSeg);
-            if (rc != 0) throw new RuntimeException("jpdfium_import_n_pages_to_one failed: " + rc);
-            MemorySegment nativePtr = ptrSeg.get(ADDRESS, 0);
-            byte[] result = nativePtr.reinterpret(lenSeg.get(JAVA_LONG, 0)).toArray(JAVA_BYTE);
-            JpdfiumH.jpdfium_free_buffer(nativePtr);
-            return result;
+        NativeGuard.acquire();
+        try {
+            try (Arena arena = Arena.ofConfined()) {
+                MemorySegment ptrSeg = arena.allocate(ADDRESS);
+                MemorySegment lenSeg = arena.allocate(JAVA_LONG);
+                int rc = JpdfiumH.jpdfium_import_n_pages_to_one(
+                        srcDoc, outputWidth, outputHeight, cols, rows, ptrSeg, lenSeg);
+                if (rc != 0) throw new RuntimeException("jpdfium_import_n_pages_to_one failed: " + rc);
+                MemorySegment nativePtr = ptrSeg.get(ADDRESS, 0);
+                byte[] result = nativePtr.reinterpret(lenSeg.get(JAVA_LONG, 0)).toArray(JAVA_BYTE);
+                JpdfiumH.jpdfium_free_buffer(nativePtr);
+                return result;
+            }
+        } finally {
+            NativeGuard.release();
         }
     }
 

--- a/jpdfium/src/main/java/stirling/software/jpdfium/panama/ActionBindings.java
+++ b/jpdfium/src/main/java/stirling/software/jpdfium/panama/ActionBindings.java
@@ -20,15 +20,15 @@ public final class ActionBindings {
     private ActionBindings() {}
 
     private static MethodHandle downcall(String name, FunctionDescriptor desc) {
-        return LINKER.downcallHandle(
+        return NativeGuard.guard(LINKER.downcallHandle(
                 LOOKUP.find(name).orElseThrow(() -> new UnsatisfiedLinkError("PDFium symbol not found: " + name)),
-                desc);
+                desc));
     }
 
     private static MethodHandle downcallCritical(String name, FunctionDescriptor desc) {
-        return LINKER.downcallHandle(
+        return NativeGuard.guard(LINKER.downcallHandle(
                 LOOKUP.find(name).orElseThrow(() -> new UnsatisfiedLinkError("PDFium symbol not found: " + name)),
-                desc, Linker.Option.critical(false));
+                desc, Linker.Option.critical(false)));
     }
 
     public static final MethodHandle FPDFAction_GetType = downcallCritical("FPDFAction_GetType",

--- a/jpdfium/src/main/java/stirling/software/jpdfium/panama/AnnotationBindings.java
+++ b/jpdfium/src/main/java/stirling/software/jpdfium/panama/AnnotationBindings.java
@@ -24,15 +24,15 @@ public final class AnnotationBindings {
     private AnnotationBindings() {}
 
     private static MethodHandle downcall(String name, FunctionDescriptor desc) {
-        return LINKER.downcallHandle(
+        return NativeGuard.guard(LINKER.downcallHandle(
                 LOOKUP.find(name).orElseThrow(() -> new UnsatisfiedLinkError("PDFium symbol not found: " + name)),
-                desc);
+                desc));
     }
 
     private static MethodHandle downcallCritical(String name, FunctionDescriptor desc) {
-        return LINKER.downcallHandle(
+        return NativeGuard.guard(LINKER.downcallHandle(
                 LOOKUP.find(name).orElseThrow(() -> new UnsatisfiedLinkError("PDFium symbol not found: " + name)),
-                desc, Linker.Option.critical(false));
+                desc, Linker.Option.critical(false)));
     }
 
     /** Layout of {@code FS_RECTF}: {@code { float left, top, right, bottom }}. */

--- a/jpdfium/src/main/java/stirling/software/jpdfium/panama/AttachmentBindings.java
+++ b/jpdfium/src/main/java/stirling/software/jpdfium/panama/AttachmentBindings.java
@@ -18,15 +18,15 @@ public final class AttachmentBindings {
     private AttachmentBindings() {}
 
     private static MethodHandle downcall(String name, FunctionDescriptor desc) {
-        return LINKER.downcallHandle(
+        return NativeGuard.guard(LINKER.downcallHandle(
                 LOOKUP.find(name).orElseThrow(() -> new UnsatisfiedLinkError("PDFium symbol not found: " + name)),
-                desc);
+                desc));
     }
 
     private static MethodHandle downcallCritical(String name, FunctionDescriptor desc) {
-        return LINKER.downcallHandle(
+        return NativeGuard.guard(LINKER.downcallHandle(
                 LOOKUP.find(name).orElseThrow(() -> new UnsatisfiedLinkError("PDFium symbol not found: " + name)),
-                desc, Linker.Option.critical(false));
+                desc, Linker.Option.critical(false)));
     }
 
     public static final MethodHandle FPDFDoc_GetAttachmentCount = downcallCritical("FPDFDoc_GetAttachmentCount",

--- a/jpdfium/src/main/java/stirling/software/jpdfium/panama/BookmarkBindings.java
+++ b/jpdfium/src/main/java/stirling/software/jpdfium/panama/BookmarkBindings.java
@@ -20,15 +20,15 @@ public final class BookmarkBindings {
     private BookmarkBindings() {}
 
     private static MethodHandle downcall(String name, FunctionDescriptor desc) {
-        return LINKER.downcallHandle(
+        return NativeGuard.guard(LINKER.downcallHandle(
                 LOOKUP.find(name).orElseThrow(() -> new UnsatisfiedLinkError("PDFium symbol not found: " + name)),
-                desc);
+                desc));
     }
 
     private static MethodHandle downcallCritical(String name, FunctionDescriptor desc) {
-        return LINKER.downcallHandle(
+        return NativeGuard.guard(LINKER.downcallHandle(
                 LOOKUP.find(name).orElseThrow(() -> new UnsatisfiedLinkError("PDFium symbol not found: " + name)),
-                desc, Linker.Option.critical(false));
+                desc, Linker.Option.critical(false)));
     }
 
     public static final MethodHandle FPDFBookmark_GetFirstChild = downcallCritical("FPDFBookmark_GetFirstChild",

--- a/jpdfium/src/main/java/stirling/software/jpdfium/panama/DocBindings.java
+++ b/jpdfium/src/main/java/stirling/software/jpdfium/panama/DocBindings.java
@@ -18,15 +18,15 @@ public final class DocBindings {
     private DocBindings() {}
 
     private static MethodHandle downcall(String name, FunctionDescriptor desc) {
-        return LINKER.downcallHandle(
+        return NativeGuard.guard(LINKER.downcallHandle(
                 LOOKUP.find(name).orElseThrow(() -> new UnsatisfiedLinkError("PDFium symbol not found: " + name)),
-                desc);
+                desc));
     }
 
     private static MethodHandle downcallCritical(String name, FunctionDescriptor desc) {
-        return LINKER.downcallHandle(
+        return NativeGuard.guard(LINKER.downcallHandle(
                 LOOKUP.find(name).orElseThrow(() -> new UnsatisfiedLinkError("PDFium symbol not found: " + name)),
-                desc, Linker.Option.critical(false));
+                desc, Linker.Option.critical(false)));
     }
 
     public static final MethodHandle FPDF_GetMetaText = downcall("FPDF_GetMetaText",

--- a/jpdfium/src/main/java/stirling/software/jpdfium/panama/EmbedPdfAnnotationBindings.java
+++ b/jpdfium/src/main/java/stirling/software/jpdfium/panama/EmbedPdfAnnotationBindings.java
@@ -26,15 +26,15 @@ public final class EmbedPdfAnnotationBindings {
     private EmbedPdfAnnotationBindings() {}
 
     private static MethodHandle downcall(String name, FunctionDescriptor desc) {
-        return LINKER.downcallHandle(
+        return NativeGuard.guard(LINKER.downcallHandle(
                 LOOKUP.find(name).orElseThrow(() -> new UnsatisfiedLinkError("EmbedPDF symbol not found: " + name)),
-                desc);
+                desc));
     }
 
     private static MethodHandle downcallCritical(String name, FunctionDescriptor desc) {
-        return LINKER.downcallHandle(
+        return NativeGuard.guard(LINKER.downcallHandle(
                 LOOKUP.find(name).orElseThrow(() -> new UnsatisfiedLinkError("EmbedPDF symbol not found: " + name)),
-                desc, Linker.Option.critical(false));
+                desc, Linker.Option.critical(false)));
     }
 
     // FS_MATRIX layout: { float a, b, c, d, e, f }

--- a/jpdfium/src/main/java/stirling/software/jpdfium/panama/EmbedPdfDocumentBindings.java
+++ b/jpdfium/src/main/java/stirling/software/jpdfium/panama/EmbedPdfDocumentBindings.java
@@ -20,15 +20,15 @@ public final class EmbedPdfDocumentBindings {
     private EmbedPdfDocumentBindings() {}
 
     private static MethodHandle downcall(String name, FunctionDescriptor desc) {
-        return LINKER.downcallHandle(
+        return NativeGuard.guard(LINKER.downcallHandle(
                 LOOKUP.find(name).orElseThrow(() -> new UnsatisfiedLinkError("EmbedPDF symbol not found: " + name)),
-                desc);
+                desc));
     }
 
     private static MethodHandle downcallCritical(String name, FunctionDescriptor desc) {
-        return LINKER.downcallHandle(
+        return NativeGuard.guard(LINKER.downcallHandle(
                 LOOKUP.find(name).orElseThrow(() -> new UnsatisfiedLinkError("EmbedPDF symbol not found: " + name)),
-                desc, Linker.Option.critical(false));
+                desc, Linker.Option.critical(false)));
     }
 
     /** Bit 3: Print document. */

--- a/jpdfium/src/main/java/stirling/software/jpdfium/panama/FlashTextLib.java
+++ b/jpdfium/src/main/java/stirling/software/jpdfium/panama/FlashTextLib.java
@@ -18,39 +18,64 @@ public final class FlashTextLib {
     private FlashTextLib() {}
 
     public static long create() {
-        try (Arena a = Arena.ofConfined()) {
-            MemorySegment hSeg = a.allocate(JAVA_LONG);
-            JpdfiumLib.check(JpdfiumH.jpdfium_flashtext_create(hSeg), "flashtextCreate");
-            return hSeg.get(JAVA_LONG, 0);
+        NativeGuard.acquire();
+        try {
+            try (Arena a = Arena.ofConfined()) {
+                MemorySegment hSeg = a.allocate(JAVA_LONG);
+                JpdfiumLib.check(JpdfiumH.jpdfium_flashtext_create(hSeg), "flashtextCreate");
+                return hSeg.get(JAVA_LONG, 0);
+            }
+        } finally {
+            NativeGuard.release();
         }
     }
 
     public static void addKeyword(long handle, String keyword, String label) {
-        try (Arena a = Arena.ofConfined()) {
-            JpdfiumLib.check(JpdfiumH.jpdfium_flashtext_add_keyword(handle,
-                    a.allocateFrom(keyword), a.allocateFrom(label)), "flashtextAddKeyword");
+        NativeGuard.acquire();
+        try {
+            try (Arena a = Arena.ofConfined()) {
+                JpdfiumLib.check(JpdfiumH.jpdfium_flashtext_add_keyword(handle,
+                        a.allocateFrom(keyword), a.allocateFrom(label)), "flashtextAddKeyword");
+            }
+        } finally {
+            NativeGuard.release();
         }
     }
 
     public static void addKeywordsJson(long handle, String json) {
-        try (Arena a = Arena.ofConfined()) {
-            JpdfiumLib.check(JpdfiumH.jpdfium_flashtext_add_keywords_json(handle,
-                    a.allocateFrom(json)), "flashtextAddKeywordsJson");
+        NativeGuard.acquire();
+        try {
+            try (Arena a = Arena.ofConfined()) {
+                JpdfiumLib.check(JpdfiumH.jpdfium_flashtext_add_keywords_json(handle,
+                        a.allocateFrom(json)), "flashtextAddKeywordsJson");
+            }
+        } finally {
+            NativeGuard.release();
         }
     }
 
     public static String find(long handle, String text) {
-        try (Arena a = Arena.ofConfined()) {
-            MemorySegment ptrSeg = a.allocate(ADDRESS);
-            JpdfiumLib.check(JpdfiumH.jpdfium_flashtext_find(handle, a.allocateFrom(text), ptrSeg), "flashtextFind");
-            MemorySegment strPtr = ptrSeg.get(ADDRESS, 0);
-            String result = strPtr.reinterpret(Long.MAX_VALUE).getString(0);
-            JpdfiumH.jpdfium_free_string(strPtr);
-            return result;
+        NativeGuard.acquire();
+        try {
+            try (Arena a = Arena.ofConfined()) {
+                MemorySegment ptrSeg = a.allocate(ADDRESS);
+                JpdfiumLib.check(JpdfiumH.jpdfium_flashtext_find(handle, a.allocateFrom(text), ptrSeg), "flashtextFind");
+                MemorySegment strPtr = ptrSeg.get(ADDRESS, 0);
+                String result = strPtr.reinterpret(Long.MAX_VALUE).getString(0);
+                JpdfiumH.jpdfium_free_string(strPtr);
+                return result;
+            }
+        } finally {
+            NativeGuard.release();
         }
     }
 
     public static void free(long handle) {
-        JpdfiumH.jpdfium_flashtext_free(handle);
+        NativeGuard.acquire();
+        try {
+            JpdfiumH.jpdfium_flashtext_free(handle);
+        } finally {
+            NativeGuard.release();
+        }
     }
 }

--- a/jpdfium/src/main/java/stirling/software/jpdfium/panama/FontLib.java
+++ b/jpdfium/src/main/java/stirling/software/jpdfium/panama/FontLib.java
@@ -16,63 +16,89 @@ public final class FontLib {
 
     static { NativeLoader.ensureLoaded(); }
 
-    private static final MethodHandle jpdfium_strip_fonts = Linker.nativeLinker().downcallHandle(
-            SymbolLookup.loaderLookup()
-                    .find("jpdfium_strip_fonts")
-                    .orElseThrow(() -> new UnsatisfiedLinkError("jpdfium_strip_fonts not found")),
-            FunctionDescriptor.of(JAVA_INT, JAVA_LONG, ADDRESS));
+    private static final MethodHandle jpdfium_strip_fonts = NativeGuard.guard(
+            Linker.nativeLinker().downcallHandle(
+                    SymbolLookup.loaderLookup()
+                            .find("jpdfium_strip_fonts")
+                            .orElseThrow(() -> new UnsatisfiedLinkError("jpdfium_strip_fonts not found")),
+                    FunctionDescriptor.of(JAVA_INT, JAVA_LONG, ADDRESS)));
 
     private FontLib() {}
 
     public static byte[] getData(long page, int fontIndex) {
-        try (Arena a = Arena.ofConfined()) {
-            MemorySegment ptrSeg = a.allocate(ADDRESS);
-            MemorySegment lenSeg = a.allocate(JAVA_LONG);
-            JpdfiumLib.check(JpdfiumH.jpdfium_font_get_data(page, fontIndex, ptrSeg, lenSeg), "fontGetData");
-            MemorySegment nativePtr = ptrSeg.get(ADDRESS, 0);
-            long len = lenSeg.get(JAVA_LONG, 0);
-            byte[] result = nativePtr.reinterpret(len).toArray(JAVA_BYTE);
-            JpdfiumH.jpdfium_free_buffer(nativePtr);
-            return result;
+        NativeGuard.acquire();
+        try {
+            try (Arena a = Arena.ofConfined()) {
+                MemorySegment ptrSeg = a.allocate(ADDRESS);
+                MemorySegment lenSeg = a.allocate(JAVA_LONG);
+                JpdfiumLib.check(JpdfiumH.jpdfium_font_get_data(page, fontIndex, ptrSeg, lenSeg), "fontGetData");
+                MemorySegment nativePtr = ptrSeg.get(ADDRESS, 0);
+                long len = lenSeg.get(JAVA_LONG, 0);
+                byte[] result = nativePtr.reinterpret(len).toArray(JAVA_BYTE);
+                JpdfiumH.jpdfium_free_buffer(nativePtr);
+                return result;
+            }
+        } finally {
+            NativeGuard.release();
         }
     }
 
     public static String classify(byte[] fontData) {
-        try (Arena a = Arena.ofConfined()) {
-            MemorySegment ptrSeg = a.allocate(ADDRESS);
-            JpdfiumLib.check(JpdfiumH.jpdfium_font_classify(
-                    a.allocateFrom(JAVA_BYTE, fontData), fontData.length, ptrSeg), "fontClassify");
-            MemorySegment strPtr = ptrSeg.get(ADDRESS, 0);
-            String result = strPtr.reinterpret(Long.MAX_VALUE).getString(0);
-            JpdfiumH.jpdfium_free_string(strPtr);
-            return result;
+        NativeGuard.acquire();
+        try {
+            try (Arena a = Arena.ofConfined()) {
+                MemorySegment ptrSeg = a.allocate(ADDRESS);
+                JpdfiumLib.check(JpdfiumH.jpdfium_font_classify(
+                        a.allocateFrom(JAVA_BYTE, fontData), fontData.length, ptrSeg), "fontClassify");
+                MemorySegment strPtr = ptrSeg.get(ADDRESS, 0);
+                String result = strPtr.reinterpret(Long.MAX_VALUE).getString(0);
+                JpdfiumH.jpdfium_free_string(strPtr);
+                return result;
+            }
+        } finally {
+            NativeGuard.release();
         }
     }
 
     public static int fixToUnicode(long doc, int pageIndex) {
-        try (Arena a = Arena.ofConfined()) {
-            MemorySegment cSeg = a.allocate(JAVA_INT);
-            JpdfiumLib.check(JpdfiumH.jpdfium_font_fix_tounicode(doc, pageIndex, cSeg), "fontFixToUnicode");
-            return cSeg.get(JAVA_INT, 0);
+        NativeGuard.acquire();
+        try {
+            try (Arena a = Arena.ofConfined()) {
+                MemorySegment cSeg = a.allocate(JAVA_INT);
+                JpdfiumLib.check(JpdfiumH.jpdfium_font_fix_tounicode(doc, pageIndex, cSeg), "fontFixToUnicode");
+                return cSeg.get(JAVA_INT, 0);
+            }
+        } finally {
+            NativeGuard.release();
         }
     }
 
     public static int repairWidths(long doc, int pageIndex) {
-        try (Arena a = Arena.ofConfined()) {
-            MemorySegment cSeg = a.allocate(JAVA_INT);
-            JpdfiumLib.check(JpdfiumH.jpdfium_font_repair_widths(doc, pageIndex, cSeg), "fontRepairWidths");
-            return cSeg.get(JAVA_INT, 0);
+        NativeGuard.acquire();
+        try {
+            try (Arena a = Arena.ofConfined()) {
+                MemorySegment cSeg = a.allocate(JAVA_INT);
+                JpdfiumLib.check(JpdfiumH.jpdfium_font_repair_widths(doc, pageIndex, cSeg), "fontRepairWidths");
+                return cSeg.get(JAVA_INT, 0);
+            }
+        } finally {
+            NativeGuard.release();
         }
     }
 
     public static String normalizePage(long doc, int pageIndex) {
-        try (Arena a = Arena.ofConfined()) {
-            MemorySegment ptrSeg = a.allocate(ADDRESS);
-            JpdfiumLib.check(JpdfiumH.jpdfium_font_normalize_page(doc, pageIndex, ptrSeg), "fontNormalizePage");
-            MemorySegment strPtr = ptrSeg.get(ADDRESS, 0);
-            String result = strPtr.reinterpret(Long.MAX_VALUE).getString(0);
-            JpdfiumH.jpdfium_free_string(strPtr);
-            return result;
+        NativeGuard.acquire();
+        try {
+            try (Arena a = Arena.ofConfined()) {
+                MemorySegment ptrSeg = a.allocate(ADDRESS);
+                JpdfiumLib.check(JpdfiumH.jpdfium_font_normalize_page(doc, pageIndex, ptrSeg), "fontNormalizePage");
+                MemorySegment strPtr = ptrSeg.get(ADDRESS, 0);
+                String result = strPtr.reinterpret(Long.MAX_VALUE).getString(0);
+                JpdfiumH.jpdfium_free_string(strPtr);
+                return result;
+            }
+        } finally {
+            NativeGuard.release();
         }
     }
 
@@ -83,31 +109,41 @@ public final class FontLib {
      * @return number of font entries removed
      */
     public static int stripFonts(long doc) {
-        try (Arena a = Arena.ofConfined()) {
-            MemorySegment cSeg = a.allocate(JAVA_INT);
-            int rc;
-            try {
-                rc = (int) jpdfium_strip_fonts.invokeExact(doc, cSeg);
-            } catch (Throwable t) { throw new RuntimeException("jpdfium_strip_fonts failed", t); }
-            JpdfiumLib.check(rc, "stripFonts");
-            return cSeg.get(JAVA_INT, 0);
+        NativeGuard.acquire();
+        try {
+            try (Arena a = Arena.ofConfined()) {
+                MemorySegment cSeg = a.allocate(JAVA_INT);
+                int rc;
+                try {
+                    rc = (int) jpdfium_strip_fonts.invokeExact(doc, cSeg);
+                } catch (Throwable t) { throw new RuntimeException("jpdfium_strip_fonts failed", t); }
+                JpdfiumLib.check(rc, "stripFonts");
+                return cSeg.get(JAVA_INT, 0);
+            }
+        } finally {
+            NativeGuard.release();
         }
     }
 
     public static byte[] subset(byte[] fontData, int[] codepoints, boolean retainGids) {
-        try (Arena a = Arena.ofConfined()) {
-            MemorySegment ptrSeg = a.allocate(ADDRESS);
-            MemorySegment lenSeg = a.allocate(JAVA_LONG);
-            JpdfiumLib.check(JpdfiumH.jpdfium_font_subset(
-                    a.allocateFrom(JAVA_BYTE, fontData), fontData.length,
-                    a.allocateFrom(JAVA_INT, codepoints), codepoints.length,
-                    retainGids ? 1 : 0,
-                    ptrSeg, lenSeg), "fontSubset");
-            MemorySegment nativePtr = ptrSeg.get(ADDRESS, 0);
-            long len = lenSeg.get(JAVA_LONG, 0);
-            byte[] result = nativePtr.reinterpret(len).toArray(JAVA_BYTE);
-            JpdfiumH.jpdfium_free_buffer(nativePtr);
-            return result;
+        NativeGuard.acquire();
+        try {
+            try (Arena a = Arena.ofConfined()) {
+                MemorySegment ptrSeg = a.allocate(ADDRESS);
+                MemorySegment lenSeg = a.allocate(JAVA_LONG);
+                JpdfiumLib.check(JpdfiumH.jpdfium_font_subset(
+                        a.allocateFrom(JAVA_BYTE, fontData), fontData.length,
+                        a.allocateFrom(JAVA_INT, codepoints), codepoints.length,
+                        retainGids ? 1 : 0,
+                        ptrSeg, lenSeg), "fontSubset");
+                MemorySegment nativePtr = ptrSeg.get(ADDRESS, 0);
+                long len = lenSeg.get(JAVA_LONG, 0);
+                byte[] result = nativePtr.reinterpret(len).toArray(JAVA_BYTE);
+                JpdfiumH.jpdfium_free_buffer(nativePtr);
+                return result;
+            }
+        } finally {
+            NativeGuard.release();
         }
     }
 }

--- a/jpdfium/src/main/java/stirling/software/jpdfium/panama/FormFillBindings.java
+++ b/jpdfium/src/main/java/stirling/software/jpdfium/panama/FormFillBindings.java
@@ -31,15 +31,15 @@ public final class FormFillBindings {
     private FormFillBindings() {}
 
     private static MethodHandle downcall(String name, FunctionDescriptor desc) {
-        return LINKER.downcallHandle(
+        return NativeGuard.guard(LINKER.downcallHandle(
                 LOOKUP.find(name).orElseThrow(() -> new UnsatisfiedLinkError("PDFium symbol not found: " + name)),
-                desc);
+                desc));
     }
 
     private static MethodHandle downcallCritical(String name, FunctionDescriptor desc) {
-        return LINKER.downcallHandle(
+        return NativeGuard.guard(LINKER.downcallHandle(
                 LOOKUP.find(name).orElseThrow(() -> new UnsatisfiedLinkError("PDFium symbol not found: " + name)),
-                desc, Linker.Option.critical(false));
+                desc, Linker.Option.critical(false)));
     }
 
     /**

--- a/jpdfium/src/main/java/stirling/software/jpdfium/panama/GlyphLib.java
+++ b/jpdfium/src/main/java/stirling/software/jpdfium/panama/GlyphLib.java
@@ -24,21 +24,26 @@ public final class GlyphLib {
 
     public static GlyphRedactResult redactGlyphAware(long page, String[] words,
                                                       int argb, float padding, int flags) {
-        if (words == null || words.length == 0) return new GlyphRedactResult(0, "[]");
-        try (Arena a = Arena.ofConfined()) {
-            MemorySegment ptrs = a.allocate(ADDRESS, words.length);
-            for (int i = 0; i < words.length; i++) {
-                ptrs.setAtIndex(ADDRESS, i, a.allocateFrom(words[i]));
+        NativeGuard.acquire();
+        try {
+            if (words == null || words.length == 0) return new GlyphRedactResult(0, "[]");
+            try (Arena a = Arena.ofConfined()) {
+                MemorySegment ptrs = a.allocate(ADDRESS, words.length);
+                for (int i = 0; i < words.length; i++) {
+                    ptrs.setAtIndex(ADDRESS, i, a.allocateFrom(words[i]));
+                }
+                MemorySegment countSeg = a.allocate(JAVA_INT);
+                MemorySegment jsonSeg  = a.allocate(ADDRESS);
+                JpdfiumLib.check(JpdfiumH.jpdfium_redact_glyph_aware(page, ptrs, words.length,
+                        argb, padding, flags, countSeg, jsonSeg), "redactGlyphAware");
+                int count = countSeg.get(JAVA_INT, 0);
+                MemorySegment strPtr = jsonSeg.get(ADDRESS, 0);
+                String json = strPtr.reinterpret(Long.MAX_VALUE).getString(0);
+                JpdfiumH.jpdfium_free_string(strPtr);
+                return new GlyphRedactResult(count, json);
             }
-            MemorySegment countSeg = a.allocate(JAVA_INT);
-            MemorySegment jsonSeg  = a.allocate(ADDRESS);
-            JpdfiumLib.check(JpdfiumH.jpdfium_redact_glyph_aware(page, ptrs, words.length,
-                    argb, padding, flags, countSeg, jsonSeg), "redactGlyphAware");
-            int count = countSeg.get(JAVA_INT, 0);
-            MemorySegment strPtr = jsonSeg.get(ADDRESS, 0);
-            String json = strPtr.reinterpret(Long.MAX_VALUE).getString(0);
-            JpdfiumH.jpdfium_free_string(strPtr);
-            return new GlyphRedactResult(count, json);
+        } finally {
+            NativeGuard.release();
         }
     }
 }

--- a/jpdfium/src/main/java/stirling/software/jpdfium/panama/IcuLib.java
+++ b/jpdfium/src/main/java/stirling/software/jpdfium/panama/IcuLib.java
@@ -15,35 +15,50 @@ public final class IcuLib {
     private IcuLib() {}
 
     public static String normalizeNfc(String text) {
-        try (Arena a = Arena.ofConfined()) {
-            MemorySegment ptrSeg = a.allocate(ADDRESS);
-            JpdfiumLib.check(JpdfiumH.jpdfium_icu_normalize_nfc(a.allocateFrom(text), ptrSeg), "icuNormalizeNfc");
-            MemorySegment strPtr = ptrSeg.get(ADDRESS, 0);
-            String result = strPtr.reinterpret(Long.MAX_VALUE).getString(0);
-            JpdfiumH.jpdfium_free_string(strPtr);
-            return result;
+        NativeGuard.acquire();
+        try {
+            try (Arena a = Arena.ofConfined()) {
+                MemorySegment ptrSeg = a.allocate(ADDRESS);
+                JpdfiumLib.check(JpdfiumH.jpdfium_icu_normalize_nfc(a.allocateFrom(text), ptrSeg), "icuNormalizeNfc");
+                MemorySegment strPtr = ptrSeg.get(ADDRESS, 0);
+                String result = strPtr.reinterpret(Long.MAX_VALUE).getString(0);
+                JpdfiumH.jpdfium_free_string(strPtr);
+                return result;
+            }
+        } finally {
+            NativeGuard.release();
         }
     }
 
     public static String breakSentences(String text) {
-        try (Arena a = Arena.ofConfined()) {
-            MemorySegment ptrSeg = a.allocate(ADDRESS);
-            JpdfiumLib.check(JpdfiumH.jpdfium_icu_break_sentences(a.allocateFrom(text), ptrSeg), "icuBreakSentences");
-            MemorySegment strPtr = ptrSeg.get(ADDRESS, 0);
-            String result = strPtr.reinterpret(Long.MAX_VALUE).getString(0);
-            JpdfiumH.jpdfium_free_string(strPtr);
-            return result;
+        NativeGuard.acquire();
+        try {
+            try (Arena a = Arena.ofConfined()) {
+                MemorySegment ptrSeg = a.allocate(ADDRESS);
+                JpdfiumLib.check(JpdfiumH.jpdfium_icu_break_sentences(a.allocateFrom(text), ptrSeg), "icuBreakSentences");
+                MemorySegment strPtr = ptrSeg.get(ADDRESS, 0);
+                String result = strPtr.reinterpret(Long.MAX_VALUE).getString(0);
+                JpdfiumH.jpdfium_free_string(strPtr);
+                return result;
+            }
+        } finally {
+            NativeGuard.release();
         }
     }
 
     public static String bidiReorder(String text) {
-        try (Arena a = Arena.ofConfined()) {
-            MemorySegment ptrSeg = a.allocate(ADDRESS);
-            JpdfiumLib.check(JpdfiumH.jpdfium_icu_bidi_reorder(a.allocateFrom(text), ptrSeg), "icuBidiReorder");
-            MemorySegment strPtr = ptrSeg.get(ADDRESS, 0);
-            String result = strPtr.reinterpret(Long.MAX_VALUE).getString(0);
-            JpdfiumH.jpdfium_free_string(strPtr);
-            return result;
+        NativeGuard.acquire();
+        try {
+            try (Arena a = Arena.ofConfined()) {
+                MemorySegment ptrSeg = a.allocate(ADDRESS);
+                JpdfiumLib.check(JpdfiumH.jpdfium_icu_bidi_reorder(a.allocateFrom(text), ptrSeg), "icuBidiReorder");
+                MemorySegment strPtr = ptrSeg.get(ADDRESS, 0);
+                String result = strPtr.reinterpret(Long.MAX_VALUE).getString(0);
+                JpdfiumH.jpdfium_free_string(strPtr);
+                return result;
+            }
+        } finally {
+            NativeGuard.release();
         }
     }
 }

--- a/jpdfium/src/main/java/stirling/software/jpdfium/panama/ImageObjBindings.java
+++ b/jpdfium/src/main/java/stirling/software/jpdfium/panama/ImageObjBindings.java
@@ -20,15 +20,15 @@ public final class ImageObjBindings {
     private ImageObjBindings() {}
 
     private static MethodHandle downcall(String name, FunctionDescriptor desc) {
-        return LINKER.downcallHandle(
+        return NativeGuard.guard(LINKER.downcallHandle(
                 LOOKUP.find(name).orElseThrow(() -> new UnsatisfiedLinkError("PDFium symbol not found: " + name)),
-                desc);
+                desc));
     }
 
     private static MethodHandle downcallCritical(String name, FunctionDescriptor desc) {
-        return LINKER.downcallHandle(
+        return NativeGuard.guard(LINKER.downcallHandle(
                 LOOKUP.find(name).orElseThrow(() -> new UnsatisfiedLinkError("PDFium symbol not found: " + name)),
-                desc, Linker.Option.critical(false));
+                desc, Linker.Option.critical(false)));
     }
 
     /**

--- a/jpdfium/src/main/java/stirling/software/jpdfium/panama/JavaScriptBindings.java
+++ b/jpdfium/src/main/java/stirling/software/jpdfium/panama/JavaScriptBindings.java
@@ -18,15 +18,15 @@ public final class JavaScriptBindings {
     private JavaScriptBindings() {}
 
     private static MethodHandle downcall(String name, FunctionDescriptor desc) {
-        return LINKER.downcallHandle(
+        return NativeGuard.guard(LINKER.downcallHandle(
                 LOOKUP.find(name).orElseThrow(() -> new UnsatisfiedLinkError("PDFium symbol not found: " + name)),
-                desc);
+                desc));
     }
 
     private static MethodHandle downcallCritical(String name, FunctionDescriptor desc) {
-        return LINKER.downcallHandle(
+        return NativeGuard.guard(LINKER.downcallHandle(
                 LOOKUP.find(name).orElseThrow(() -> new UnsatisfiedLinkError("PDFium symbol not found: " + name)),
-                desc, Linker.Option.critical(false));
+                desc, Linker.Option.critical(false)));
     }
 
     /** Count document-level JavaScript actions. */

--- a/jpdfium/src/main/java/stirling/software/jpdfium/panama/JpdfiumLib.java
+++ b/jpdfium/src/main/java/stirling/software/jpdfium/panama/JpdfiumLib.java
@@ -15,8 +15,10 @@ import static java.lang.foreign.ValueLayout.*;
  * Handles NativeLoader bootstrap, Arena lifecycle, String/MemorySegment conversion,
  * and result-code to exception translation.
  *
- * <p>All public methods are thread-safe with respect to independent documents,
- * but a single document handle must not be accessed concurrently.
+ * <p>PDFium keeps process-wide mutable state, so it is not thread-safe even across
+ * independent documents. Every method here serialises on {@link NativeGuard}, which
+ * makes concurrent calls safe. A single document handle must still not be accessed
+ * concurrently - the guard prevents native corruption, not logical interleaving.
  *
  * <p>Advanced feature bindings are split into focused companion classes:
  * {@link Pcre2Lib}, {@link FlashTextLib}, {@link FontLib},
@@ -45,7 +47,9 @@ public final class JpdfiumLib {
         NativeLoader.ensureLoaded();
         int rc = JpdfiumH.jpdfium_init();
         if (rc != OK) throw new JPDFiumException("jpdfium_init failed: " + rc);
-        Runtime.getRuntime().addShutdownHook(new Thread(JpdfiumH::jpdfium_destroy));
+        // Wait for any in-flight native call before tearing the library down;
+        // FPDF_DestroyLibrary while another thread is inside PDFium segfaults.
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> NativeGuard.run(JpdfiumH::jpdfium_destroy)));
     }
 
     private JpdfiumLib() {}
@@ -62,184 +66,289 @@ public final class JpdfiumLib {
     }
 
     public static long docOpen(String path) {
-        try (Arena a = Arena.ofConfined()) {
-            MemorySegment hSeg = a.allocate(JAVA_LONG);
-            check(JpdfiumH.jpdfium_doc_open(a.allocateFrom(path), hSeg), "docOpen: " + path);
-            return hSeg.get(JAVA_LONG, 0);
+        NativeGuard.acquire();
+        try {
+            try (Arena a = Arena.ofConfined()) {
+                MemorySegment hSeg = a.allocate(JAVA_LONG);
+                check(JpdfiumH.jpdfium_doc_open(a.allocateFrom(path), hSeg), "docOpen: " + path);
+                return hSeg.get(JAVA_LONG, 0);
+            }
+        } finally {
+            NativeGuard.release();
         }
     }
 
     public static long docOpenBytes(byte[] data) {
-        try (Arena a = Arena.ofConfined()) {
-            MemorySegment hSeg = a.allocate(JAVA_LONG);
-            // The bridge copies the data - the arena is freed on return.
-            check(JpdfiumH.jpdfium_doc_open_bytes(a.allocateFrom(JAVA_BYTE, data), data.length, hSeg), "docOpenBytes");
-            return hSeg.get(JAVA_LONG, 0);
+        NativeGuard.acquire();
+        try {
+            try (Arena a = Arena.ofConfined()) {
+                MemorySegment hSeg = a.allocate(JAVA_LONG);
+                // The bridge copies the data - the arena is freed on return.
+                check(JpdfiumH.jpdfium_doc_open_bytes(a.allocateFrom(JAVA_BYTE, data), data.length, hSeg), "docOpenBytes");
+                return hSeg.get(JAVA_LONG, 0);
+            }
+        } finally {
+            NativeGuard.release();
         }
     }
 
     public static long docOpenProtected(String path, String password) {
-        try (Arena a = Arena.ofConfined()) {
-            MemorySegment hSeg = a.allocate(JAVA_LONG);
-            check(JpdfiumH.jpdfium_doc_open_protected(a.allocateFrom(path), a.allocateFrom(password), hSeg), "docOpenProtected: " + path);
-            return hSeg.get(JAVA_LONG, 0);
+        NativeGuard.acquire();
+        try {
+            try (Arena a = Arena.ofConfined()) {
+                MemorySegment hSeg = a.allocate(JAVA_LONG);
+                check(JpdfiumH.jpdfium_doc_open_protected(a.allocateFrom(path), a.allocateFrom(password), hSeg), "docOpenProtected: " + path);
+                return hSeg.get(JAVA_LONG, 0);
+            }
+        } finally {
+            NativeGuard.release();
         }
     }
 
     public static int docPageCount(long doc) {
-        try (Arena a = Arena.ofConfined()) {
-            MemorySegment cSeg = a.allocate(JAVA_INT);
-            check(JpdfiumH.jpdfium_doc_page_count(doc, cSeg), "docPageCount");
-            return cSeg.get(JAVA_INT, 0);
+        NativeGuard.acquire();
+        try {
+            try (Arena a = Arena.ofConfined()) {
+                MemorySegment cSeg = a.allocate(JAVA_INT);
+                check(JpdfiumH.jpdfium_doc_page_count(doc, cSeg), "docPageCount");
+                return cSeg.get(JAVA_INT, 0);
+            }
+        } finally {
+            NativeGuard.release();
         }
     }
 
     public static void docSave(long doc, String path) {
-        try (Arena a = Arena.ofConfined()) {
-            check(JpdfiumH.jpdfium_doc_save(doc, a.allocateFrom(path)), "docSave: " + path);
+        NativeGuard.acquire();
+        try {
+            try (Arena a = Arena.ofConfined()) {
+                check(JpdfiumH.jpdfium_doc_save(doc, a.allocateFrom(path)), "docSave: " + path);
+            }
+        } finally {
+            NativeGuard.release();
         }
     }
 
     public static byte[] docSaveBytes(long doc) {
-        try (Arena a = Arena.ofConfined()) {
-            MemorySegment ptrSeg = a.allocate(ADDRESS);
-            MemorySegment lenSeg = a.allocate(JAVA_LONG);
-            check(JpdfiumH.jpdfium_doc_save_bytes(doc, ptrSeg, lenSeg), "docSaveBytes");
-            MemorySegment nativePtr = ptrSeg.get(ADDRESS, 0);
-            byte[] result = nativePtr.reinterpret(lenSeg.get(JAVA_LONG, 0)).toArray(JAVA_BYTE);
-            JpdfiumH.jpdfium_free_buffer(nativePtr);
-            return result;
+        NativeGuard.acquire();
+        try {
+            try (Arena a = Arena.ofConfined()) {
+                MemorySegment ptrSeg = a.allocate(ADDRESS);
+                MemorySegment lenSeg = a.allocate(JAVA_LONG);
+                check(JpdfiumH.jpdfium_doc_save_bytes(doc, ptrSeg, lenSeg), "docSaveBytes");
+                MemorySegment nativePtr = ptrSeg.get(ADDRESS, 0);
+                byte[] result = nativePtr.reinterpret(lenSeg.get(JAVA_LONG, 0)).toArray(JAVA_BYTE);
+                JpdfiumH.jpdfium_free_buffer(nativePtr);
+                return result;
+            }
+        } finally {
+            NativeGuard.release();
         }
     }
 
     public static void docClose(long doc) {
-        JpdfiumH.jpdfium_doc_close(doc);
+        NativeGuard.acquire();
+        try {
+            JpdfiumH.jpdfium_doc_close(doc);
+        } finally {
+            NativeGuard.release();
+        }
     }
 
     public static long pageOpen(long doc, int idx) {
-        try (Arena a = Arena.ofConfined()) {
-            MemorySegment hSeg = a.allocate(JAVA_LONG);
-            check(JpdfiumH.jpdfium_page_open(doc, idx, hSeg), "pageOpen: " + idx);
-            return hSeg.get(JAVA_LONG, 0);
+        NativeGuard.acquire();
+        try {
+            try (Arena a = Arena.ofConfined()) {
+                MemorySegment hSeg = a.allocate(JAVA_LONG);
+                check(JpdfiumH.jpdfium_page_open(doc, idx, hSeg), "pageOpen: " + idx);
+                return hSeg.get(JAVA_LONG, 0);
+            }
+        } finally {
+            NativeGuard.release();
         }
     }
 
     public static float pageWidth(long page) {
-        try (Arena a = Arena.ofConfined()) {
-            MemorySegment s = a.allocate(JAVA_FLOAT);
-            check(JpdfiumH.jpdfium_page_width(page, s), "pageWidth");
-            return s.get(JAVA_FLOAT, 0);
+        NativeGuard.acquire();
+        try {
+            try (Arena a = Arena.ofConfined()) {
+                MemorySegment s = a.allocate(JAVA_FLOAT);
+                check(JpdfiumH.jpdfium_page_width(page, s), "pageWidth");
+                return s.get(JAVA_FLOAT, 0);
+            }
+        } finally {
+            NativeGuard.release();
         }
     }
 
     public static float pageHeight(long page) {
-        try (Arena a = Arena.ofConfined()) {
-            MemorySegment s = a.allocate(JAVA_FLOAT);
-            check(JpdfiumH.jpdfium_page_height(page, s), "pageHeight");
-            return s.get(JAVA_FLOAT, 0);
+        NativeGuard.acquire();
+        try {
+            try (Arena a = Arena.ofConfined()) {
+                MemorySegment s = a.allocate(JAVA_FLOAT);
+                check(JpdfiumH.jpdfium_page_height(page, s), "pageHeight");
+                return s.get(JAVA_FLOAT, 0);
+            }
+        } finally {
+            NativeGuard.release();
         }
     }
 
     public static void pageClose(long page) {
-        JpdfiumH.jpdfium_page_close(page);
+        NativeGuard.acquire();
+        try {
+            JpdfiumH.jpdfium_page_close(page);
+        } finally {
+            NativeGuard.release();
+        }
     }
 
     public static RenderResult renderPage(long page, int dpi) {
-        try (Arena a = Arena.ofConfined()) {
-            MemorySegment ptrSeg = a.allocate(ADDRESS);
-            MemorySegment wSeg   = a.allocate(JAVA_INT);
-            MemorySegment hSeg   = a.allocate(JAVA_INT);
-            check(JpdfiumH.jpdfium_render_page(page, dpi, ptrSeg, wSeg, hSeg), "renderPage");
-            int w = wSeg.get(JAVA_INT, 0);
-            int h = hSeg.get(JAVA_INT, 0);
-            MemorySegment nativePtr = ptrSeg.get(ADDRESS, 0);
-            byte[] rgba = nativePtr.reinterpret((long) w * h * 4).toArray(JAVA_BYTE);
-            JpdfiumH.jpdfium_free_buffer(nativePtr);
-            return new RenderResult(w, h, rgba);
+        NativeGuard.acquire();
+        try {
+            try (Arena a = Arena.ofConfined()) {
+                MemorySegment ptrSeg = a.allocate(ADDRESS);
+                MemorySegment wSeg   = a.allocate(JAVA_INT);
+                MemorySegment hSeg   = a.allocate(JAVA_INT);
+                check(JpdfiumH.jpdfium_render_page(page, dpi, ptrSeg, wSeg, hSeg), "renderPage");
+                int w = wSeg.get(JAVA_INT, 0);
+                int h = hSeg.get(JAVA_INT, 0);
+                MemorySegment nativePtr = ptrSeg.get(ADDRESS, 0);
+                byte[] rgba = nativePtr.reinterpret((long) w * h * 4).toArray(JAVA_BYTE);
+                JpdfiumH.jpdfium_free_buffer(nativePtr);
+                return new RenderResult(w, h, rgba);
+            }
+        } finally {
+            NativeGuard.release();
         }
     }
 
     public static String textGetChars(long page) {
-        try (Arena a = Arena.ofConfined()) {
-            MemorySegment ptrSeg = a.allocate(ADDRESS);
-            check(JpdfiumH.jpdfium_text_get_chars(page, ptrSeg), "textGetChars");
-            MemorySegment strPtr = ptrSeg.get(ADDRESS, 0);
-            String result = strPtr.reinterpret(Long.MAX_VALUE).getString(0);
-            JpdfiumH.jpdfium_free_string(strPtr);
-            return result;
+        NativeGuard.acquire();
+        try {
+            try (Arena a = Arena.ofConfined()) {
+                MemorySegment ptrSeg = a.allocate(ADDRESS);
+                check(JpdfiumH.jpdfium_text_get_chars(page, ptrSeg), "textGetChars");
+                MemorySegment strPtr = ptrSeg.get(ADDRESS, 0);
+                String result = strPtr.reinterpret(Long.MAX_VALUE).getString(0);
+                JpdfiumH.jpdfium_free_string(strPtr);
+                return result;
+            }
+        } finally {
+            NativeGuard.release();
         }
     }
 
     public static String textFind(long page, String query) {
-        try (Arena a = Arena.ofConfined()) {
-            MemorySegment ptrSeg = a.allocate(ADDRESS);
-            check(JpdfiumH.jpdfium_text_find(page, a.allocateFrom(query), ptrSeg), "textFind");
-            MemorySegment strPtr = ptrSeg.get(ADDRESS, 0);
-            String result = strPtr.reinterpret(Long.MAX_VALUE).getString(0);
-            JpdfiumH.jpdfium_free_string(strPtr);
-            return result;
+        NativeGuard.acquire();
+        try {
+            try (Arena a = Arena.ofConfined()) {
+                MemorySegment ptrSeg = a.allocate(ADDRESS);
+                check(JpdfiumH.jpdfium_text_find(page, a.allocateFrom(query), ptrSeg), "textFind");
+                MemorySegment strPtr = ptrSeg.get(ADDRESS, 0);
+                String result = strPtr.reinterpret(Long.MAX_VALUE).getString(0);
+                JpdfiumH.jpdfium_free_string(strPtr);
+                return result;
+            }
+        } finally {
+            NativeGuard.release();
         }
     }
 
     public static void redactRegion(long page, float x, float y, float w, float h, int argb, boolean removeContent) {
-        check(JpdfiumH.jpdfium_redact_region(page, x, y, w, h, argb, removeContent ? 1 : 0), "redactRegion");
+        NativeGuard.acquire();
+        try {
+            check(JpdfiumH.jpdfium_redact_region(page, x, y, w, h, argb, removeContent ? 1 : 0), "redactRegion");
+        } finally {
+            NativeGuard.release();
+        }
     }
 
     public static void redactPattern(long page, String pattern, int argb, boolean removeContent) {
-        try (Arena a = Arena.ofConfined()) {
-            check(JpdfiumH.jpdfium_redact_pattern(page, a.allocateFrom(pattern), argb, removeContent ? 1 : 0), "redactPattern");
+        NativeGuard.acquire();
+        try {
+            try (Arena a = Arena.ofConfined()) {
+                check(JpdfiumH.jpdfium_redact_pattern(page, a.allocateFrom(pattern), argb, removeContent ? 1 : 0), "redactPattern");
+            }
+        } finally {
+            NativeGuard.release();
         }
     }
 
     public static void redactWords(long page, String[] words, int argb, float padding,
                                     boolean wholeWord, boolean useRegex, boolean removeContent) {
-        if (words == null || words.length == 0) return;
-        try (Arena a = Arena.ofConfined()) {
-            MemorySegment ptrs = a.allocate(ADDRESS, words.length);
-            for (int i = 0; i < words.length; i++) {
-                MemorySegment s = a.allocateFrom(words[i]);
-                ptrs.setAtIndex(ADDRESS, i, s);
+        NativeGuard.acquire();
+        try {
+            if (words == null || words.length == 0) return;
+            try (Arena a = Arena.ofConfined()) {
+                MemorySegment ptrs = a.allocate(ADDRESS, words.length);
+                for (int i = 0; i < words.length; i++) {
+                    MemorySegment s = a.allocateFrom(words[i]);
+                    ptrs.setAtIndex(ADDRESS, i, s);
+                }
+                check(JpdfiumH.jpdfium_redact_words(page, ptrs, words.length, argb, padding,
+                        wholeWord ? 1 : 0, useRegex ? 1 : 0, removeContent ? 1 : 0), "redactWords");
             }
-            check(JpdfiumH.jpdfium_redact_words(page, ptrs, words.length, argb, padding,
-                    wholeWord ? 1 : 0, useRegex ? 1 : 0, removeContent ? 1 : 0), "redactWords");
+        } finally {
+            NativeGuard.release();
         }
     }
 
     public static int redactWordsEx(long page, String[] words, int argb, float padding,
                                      boolean wholeWord, boolean useRegex, boolean removeContent,
                                      boolean caseSensitive) {
-        if (words == null || words.length == 0) return 0;
-        try (Arena a = Arena.ofConfined()) {
-            MemorySegment ptrs = a.allocate(ADDRESS, words.length);
-            for (int i = 0; i < words.length; i++) {
-                MemorySegment s = a.allocateFrom(words[i]);
-                ptrs.setAtIndex(ADDRESS, i, s);
+        NativeGuard.acquire();
+        try {
+            if (words == null || words.length == 0) return 0;
+            try (Arena a = Arena.ofConfined()) {
+                MemorySegment ptrs = a.allocate(ADDRESS, words.length);
+                for (int i = 0; i < words.length; i++) {
+                    MemorySegment s = a.allocateFrom(words[i]);
+                    ptrs.setAtIndex(ADDRESS, i, s);
+                }
+                MemorySegment countSeg = a.allocate(JAVA_INT);
+                check(JpdfiumH.jpdfium_redact_words_ex(page, ptrs, words.length, argb, padding,
+                        wholeWord ? 1 : 0, useRegex ? 1 : 0, removeContent ? 1 : 0,
+                        caseSensitive ? 1 : 0, countSeg), "redactWordsEx");
+                return countSeg.get(JAVA_INT, 0);
             }
-            MemorySegment countSeg = a.allocate(JAVA_INT);
-            check(JpdfiumH.jpdfium_redact_words_ex(page, ptrs, words.length, argb, padding,
-                    wholeWord ? 1 : 0, useRegex ? 1 : 0, removeContent ? 1 : 0,
-                    caseSensitive ? 1 : 0, countSeg), "redactWordsEx");
-            return countSeg.get(JAVA_INT, 0);
+        } finally {
+            NativeGuard.release();
         }
     }
 
     public static void pageFlatten(long page) {
-        check(JpdfiumH.jpdfium_page_flatten(page), "pageFlatten");
+        NativeGuard.acquire();
+        try {
+            check(JpdfiumH.jpdfium_page_flatten(page), "pageFlatten");
+        } finally {
+            NativeGuard.release();
+        }
     }
 
     public static String textGetCharPositions(long page) {
-        try (Arena a = Arena.ofConfined()) {
-            MemorySegment ptrSeg = a.allocate(ADDRESS);
-            check(JpdfiumH.jpdfium_text_get_char_positions(page, ptrSeg), "textGetCharPositions");
-            MemorySegment strPtr = ptrSeg.get(ADDRESS, 0);
-            String result = strPtr.reinterpret(Long.MAX_VALUE).getString(0);
-            JpdfiumH.jpdfium_free_string(strPtr);
-            return result;
+        NativeGuard.acquire();
+        try {
+            try (Arena a = Arena.ofConfined()) {
+                MemorySegment ptrSeg = a.allocate(ADDRESS);
+                check(JpdfiumH.jpdfium_text_get_char_positions(page, ptrSeg), "textGetCharPositions");
+                MemorySegment strPtr = ptrSeg.get(ADDRESS, 0);
+                String result = strPtr.reinterpret(Long.MAX_VALUE).getString(0);
+                JpdfiumH.jpdfium_free_string(strPtr);
+                return result;
+            }
+        } finally {
+            NativeGuard.release();
         }
     }
 
     public static void pageToImage(long doc, int pageIndex, int dpi) {
-        check(JpdfiumH.jpdfium_page_to_image(doc, pageIndex, dpi), "pageToImage");
+        NativeGuard.acquire();
+        try {
+            check(JpdfiumH.jpdfium_page_to_image(doc, pageIndex, dpi), "pageToImage");
+        } finally {
+            NativeGuard.release();
+        }
     }
 
     /**
@@ -249,10 +358,15 @@ public final class JpdfiumLib {
      * @return the annotation index within the page's annotation array
      */
     public static int annotCreateRedact(long page, float x, float y, float w, float h, int argb) {
-        try (Arena a = Arena.ofConfined()) {
-            MemorySegment idxSeg = a.allocate(JAVA_INT);
-            check(JpdfiumH.jpdfium_annot_create_redact(page, x, y, w, h, argb, idxSeg), "annotCreateRedact");
-            return idxSeg.get(JAVA_INT, 0);
+        NativeGuard.acquire();
+        try {
+            try (Arena a = Arena.ofConfined()) {
+                MemorySegment idxSeg = a.allocate(JAVA_INT);
+                check(JpdfiumH.jpdfium_annot_create_redact(page, x, y, w, h, argb, idxSeg), "annotCreateRedact");
+                return idxSeg.get(JAVA_INT, 0);
+            }
+        } finally {
+            NativeGuard.release();
         }
     }
 
@@ -265,49 +379,74 @@ public final class JpdfiumLib {
     public static int redactMarkWords(long page, String[] words, float padding,
                                        boolean wholeWord, boolean useRegex,
                                        boolean caseSensitive, int argb) {
-        if (words == null || words.length == 0) return 0;
-        try (Arena a = Arena.ofConfined()) {
-            MemorySegment ptrs = a.allocate(ADDRESS, words.length);
-            for (int i = 0; i < words.length; i++) {
-                ptrs.setAtIndex(ADDRESS, i, a.allocateFrom(words[i]));
+        NativeGuard.acquire();
+        try {
+            if (words == null || words.length == 0) return 0;
+            try (Arena a = Arena.ofConfined()) {
+                MemorySegment ptrs = a.allocate(ADDRESS, words.length);
+                for (int i = 0; i < words.length; i++) {
+                    ptrs.setAtIndex(ADDRESS, i, a.allocateFrom(words[i]));
+                }
+                MemorySegment countSeg = a.allocate(JAVA_INT);
+                check(JpdfiumH.jpdfium_redact_mark_words(page, ptrs, words.length, padding,
+                        wholeWord ? 1 : 0, useRegex ? 1 : 0, caseSensitive ? 1 : 0,
+                        argb, countSeg), "redactMarkWords");
+                return countSeg.get(JAVA_INT, 0);
             }
-            MemorySegment countSeg = a.allocate(JAVA_INT);
-            check(JpdfiumH.jpdfium_redact_mark_words(page, ptrs, words.length, padding,
-                    wholeWord ? 1 : 0, useRegex ? 1 : 0, caseSensitive ? 1 : 0,
-                    argb, countSeg), "redactMarkWords");
-            return countSeg.get(JAVA_INT, 0);
+        } finally {
+            NativeGuard.release();
         }
     }
 
     /** Returns the number of pending REDACT annotations on the page. */
     public static int annotCountRedacts(long page) {
-        try (Arena a = Arena.ofConfined()) {
-            MemorySegment cSeg = a.allocate(JAVA_INT);
-            check(JpdfiumH.jpdfium_annot_count_redacts(page, cSeg), "annotCountRedacts");
-            return cSeg.get(JAVA_INT, 0);
+        NativeGuard.acquire();
+        try {
+            try (Arena a = Arena.ofConfined()) {
+                MemorySegment cSeg = a.allocate(JAVA_INT);
+                check(JpdfiumH.jpdfium_annot_count_redacts(page, cSeg), "annotCountRedacts");
+                return cSeg.get(JAVA_INT, 0);
+            }
+        } finally {
+            NativeGuard.release();
         }
     }
 
     /** Returns JSON array of all REDACT annotation rects. */
     public static String annotGetRedactsJson(long page) {
-        try (Arena a = Arena.ofConfined()) {
-            MemorySegment ptrSeg = a.allocate(ADDRESS);
-            check(JpdfiumH.jpdfium_annot_get_redacts_json(page, ptrSeg), "annotGetRedactsJson");
-            MemorySegment strPtr = ptrSeg.get(ADDRESS, 0);
-            String result = strPtr.reinterpret(Long.MAX_VALUE).getString(0);
-            JpdfiumH.jpdfium_free_string(strPtr);
-            return result;
+        NativeGuard.acquire();
+        try {
+            try (Arena a = Arena.ofConfined()) {
+                MemorySegment ptrSeg = a.allocate(ADDRESS);
+                check(JpdfiumH.jpdfium_annot_get_redacts_json(page, ptrSeg), "annotGetRedactsJson");
+                MemorySegment strPtr = ptrSeg.get(ADDRESS, 0);
+                String result = strPtr.reinterpret(Long.MAX_VALUE).getString(0);
+                JpdfiumH.jpdfium_free_string(strPtr);
+                return result;
+            }
+        } finally {
+            NativeGuard.release();
         }
     }
 
     /** Remove a specific REDACT annotation by its index. */
     public static void annotRemoveRedact(long page, int annotIndex) {
-        check(JpdfiumH.jpdfium_annot_remove_redact(page, annotIndex), "annotRemoveRedact");
+        NativeGuard.acquire();
+        try {
+            check(JpdfiumH.jpdfium_annot_remove_redact(page, annotIndex), "annotRemoveRedact");
+        } finally {
+            NativeGuard.release();
+        }
     }
 
     /** Remove all REDACT annotations from the page (undo all marks). */
     public static void annotClearRedacts(long page) {
-        check(JpdfiumH.jpdfium_annot_clear_redacts(page), "annotClearRedacts");
+        NativeGuard.acquire();
+        try {
+            check(JpdfiumH.jpdfium_annot_clear_redacts(page), "annotClearRedacts");
+        } finally {
+            NativeGuard.release();
+        }
     }
 
     /**
@@ -318,10 +457,15 @@ public final class JpdfiumLib {
      * @return the number of REDACT annotations that were committed
      */
     public static int redactCommit(long page, int argb, boolean removeContent) {
-        try (Arena a = Arena.ofConfined()) {
-            MemorySegment countSeg = a.allocate(JAVA_INT);
-            check(JpdfiumH.jpdfium_redact_commit(page, argb, removeContent ? 1 : 0, countSeg), "redactCommit");
-            return countSeg.get(JAVA_INT, 0);
+        NativeGuard.acquire();
+        try {
+            try (Arena a = Arena.ofConfined()) {
+                MemorySegment countSeg = a.allocate(JAVA_INT);
+                check(JpdfiumH.jpdfium_redact_commit(page, argb, removeContent ? 1 : 0, countSeg), "redactCommit");
+                return countSeg.get(JAVA_INT, 0);
+            }
+        } finally {
+            NativeGuard.release();
         }
     }
 
@@ -330,14 +474,19 @@ public final class JpdfiumLib {
      * The document handle remains valid after this call.
      */
     public static byte[] docSaveIncremental(long doc) {
-        try (Arena a = Arena.ofConfined()) {
-            MemorySegment ptrSeg = a.allocate(ADDRESS);
-            MemorySegment lenSeg = a.allocate(JAVA_LONG);
-            check(JpdfiumH.jpdfium_doc_save_incremental(doc, ptrSeg, lenSeg), "docSaveIncremental");
-            MemorySegment nativePtr = ptrSeg.get(ADDRESS, 0);
-            byte[] result = nativePtr.reinterpret(lenSeg.get(JAVA_LONG, 0)).toArray(JAVA_BYTE);
-            JpdfiumH.jpdfium_free_buffer(nativePtr);
-            return result;
+        NativeGuard.acquire();
+        try {
+            try (Arena a = Arena.ofConfined()) {
+                MemorySegment ptrSeg = a.allocate(ADDRESS);
+                MemorySegment lenSeg = a.allocate(JAVA_LONG);
+                check(JpdfiumH.jpdfium_doc_save_incremental(doc, ptrSeg, lenSeg), "docSaveIncremental");
+                MemorySegment nativePtr = ptrSeg.get(ADDRESS, 0);
+                byte[] result = nativePtr.reinterpret(lenSeg.get(JAVA_LONG, 0)).toArray(JAVA_BYTE);
+                JpdfiumH.jpdfium_free_buffer(nativePtr);
+                return result;
+            }
+        } finally {
+            NativeGuard.release();
         }
     }
 
@@ -346,27 +495,42 @@ public final class JpdfiumLib {
      * This enables direct FFM calls to PDFium functions not covered by the bridge.
      */
     public static MemorySegment docRawHandle(long doc) {
-        long raw = JpdfiumH.jpdfium_doc_raw_handle(doc);
-        if (raw == 0) throw new JPDFiumException("Invalid document handle");
-        return FfmHelper.ptrToSegment(raw);
+        NativeGuard.acquire();
+        try {
+            long raw = JpdfiumH.jpdfium_doc_raw_handle(doc);
+            if (raw == 0) throw new JPDFiumException("Invalid document handle");
+            return FfmHelper.ptrToSegment(raw);
+        } finally {
+            NativeGuard.release();
+        }
     }
 
     /**
      * Returns the raw FPDF_PAGE pointer (as a MemorySegment) from a bridge handle.
      */
     public static MemorySegment pageRawHandle(long page) {
-        long raw = JpdfiumH.jpdfium_page_raw_handle(page);
-        if (raw == 0) throw new JPDFiumException("Invalid page handle");
-        return FfmHelper.ptrToSegment(raw);
+        NativeGuard.acquire();
+        try {
+            long raw = JpdfiumH.jpdfium_page_raw_handle(page);
+            if (raw == 0) throw new JPDFiumException("Invalid page handle");
+            return FfmHelper.ptrToSegment(raw);
+        } finally {
+            NativeGuard.release();
+        }
     }
 
     /**
      * Returns the raw FPDF_DOCUMENT pointer for the document that owns a page.
      */
     public static MemorySegment pageDocRawHandle(long page) {
-        long raw = JpdfiumH.jpdfium_page_doc_raw_handle(page);
-        if (raw == 0) throw new JPDFiumException("Invalid page handle");
-        return FfmHelper.ptrToSegment(raw);
+        NativeGuard.acquire();
+        try {
+            long raw = JpdfiumH.jpdfium_page_doc_raw_handle(page);
+            if (raw == 0) throw new JPDFiumException("Invalid page handle");
+            return FfmHelper.ptrToSegment(raw);
+        } finally {
+            NativeGuard.release();
+        }
     }
 
     /**
@@ -382,12 +546,17 @@ public final class JpdfiumLib {
      */
     public static long imageToPdf(byte[] imageData, float pageWidth, float pageHeight,
                                    float margin, int position, int imageFormat) {
-        try (Arena a = Arena.ofConfined()) {
-            MemorySegment hSeg = a.allocate(JAVA_LONG);
-            check(JpdfiumH.jpdfium_image_to_pdf(
-                    a.allocateFrom(JAVA_BYTE, imageData), imageData.length,
-                    pageWidth, pageHeight, margin, position, imageFormat, hSeg), "imageToPdf");
-            return hSeg.get(JAVA_LONG, 0);
+        NativeGuard.acquire();
+        try {
+            try (Arena a = Arena.ofConfined()) {
+                MemorySegment hSeg = a.allocate(JAVA_LONG);
+                check(JpdfiumH.jpdfium_image_to_pdf(
+                        a.allocateFrom(JAVA_BYTE, imageData), imageData.length,
+                        pageWidth, pageHeight, margin, position, imageFormat, hSeg), "imageToPdf");
+                return hSeg.get(JAVA_LONG, 0);
+            }
+        } finally {
+            NativeGuard.release();
         }
     }
 
@@ -405,11 +574,16 @@ public final class JpdfiumLib {
      */
     public static void docAddImagePage(long doc, byte[] imageData, float pageWidth, float pageHeight,
                                         float margin, int position, int imageFormat, int insertAtIndex) {
-        try (Arena a = Arena.ofConfined()) {
-            check(JpdfiumH.jpdfium_doc_add_image_page(
-                    doc, a.allocateFrom(JAVA_BYTE, imageData), imageData.length,
-                    pageWidth, pageHeight, margin, position, imageFormat, insertAtIndex),
-                    "docAddImagePage");
+        NativeGuard.acquire();
+        try {
+            try (Arena a = Arena.ofConfined()) {
+                check(JpdfiumH.jpdfium_doc_add_image_page(
+                        doc, a.allocateFrom(JAVA_BYTE, imageData), imageData.length,
+                        pageWidth, pageHeight, margin, position, imageFormat, insertAtIndex),
+                        "docAddImagePage");
+            }
+        } finally {
+            NativeGuard.release();
         }
     }
 }

--- a/jpdfium/src/main/java/stirling/software/jpdfium/panama/LinkBindings.java
+++ b/jpdfium/src/main/java/stirling/software/jpdfium/panama/LinkBindings.java
@@ -21,15 +21,15 @@ public final class LinkBindings {
     private LinkBindings() {}
 
     private static MethodHandle downcall(String name, FunctionDescriptor desc) {
-        return LINKER.downcallHandle(
+        return NativeGuard.guard(LINKER.downcallHandle(
                 LOOKUP.find(name).orElseThrow(() -> new UnsatisfiedLinkError("PDFium symbol not found: " + name)),
-                desc);
+                desc));
     }
 
     private static MethodHandle downcallCritical(String name, FunctionDescriptor desc) {
-        return LINKER.downcallHandle(
+        return NativeGuard.guard(LINKER.downcallHandle(
                 LOOKUP.find(name).orElseThrow(() -> new UnsatisfiedLinkError("PDFium symbol not found: " + name)),
-                desc, Linker.Option.critical(false));
+                desc, Linker.Option.critical(false)));
     }
 
     public static final MethodHandle FPDFLink_GetLinkAtPoint = downcallCritical("FPDFLink_GetLinkAtPoint",

--- a/jpdfium/src/main/java/stirling/software/jpdfium/panama/NativeGuard.java
+++ b/jpdfium/src/main/java/stirling/software/jpdfium/panama/NativeGuard.java
@@ -1,0 +1,102 @@
+package stirling.software.jpdfium.panama;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Serialises every native call into PDFium.
+ *
+ * <p>PDFium keeps process-wide mutable state (font manager and font cache, page
+ * module, the parser's stock-object tables, the last-error slot) that is shared
+ * by every open document. Two threads calling into PDFium at the same instant
+ * corrupt that state even when each thread owns a completely independent
+ * {@code FPDF_DOCUMENT}. The observable results are segfaults inside
+ * {@code pdfium}, heap "double free or corruption" aborts, and valid documents
+ * being reported as corrupt.
+ *
+ * <p>The bridge adds global state of its own on top of that: the lazily created
+ * {@code FT_Library} handles in {@code jpdfium_advanced.cpp} and
+ * {@code jpdfium_redact.cpp}.
+ *
+ * <p>The lock is reentrant because higher-level helpers routinely make several
+ * guarded native calls while already holding it (for example
+ * {@code PdfDocument.metadata()} resolves the raw handle through a guarded call
+ * and then walks the metadata bindings).
+ */
+public final class NativeGuard {
+
+    private static final ReentrantLock LOCK = new ReentrantLock();
+
+    private static final MethodHandle ACQUIRE;
+    private static final MethodHandle RELEASE;
+
+    static {
+        try {
+            MethodHandles.Lookup lookup = MethodHandles.lookup();
+            ACQUIRE = lookup.findStatic(NativeGuard.class, "acquire", MethodType.methodType(void.class));
+            RELEASE = lookup.findStatic(NativeGuard.class, "release", MethodType.methodType(void.class));
+        } catch (ReflectiveOperationException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    private NativeGuard() {}
+
+    public static void acquire() {
+        LOCK.lock();
+    }
+
+    public static void release() {
+        LOCK.unlock();
+    }
+
+    /** Runs the action with the PDFium lock held. */
+    public static void run(Runnable action) {
+        LOCK.lock();
+        try {
+            action.run();
+        } finally {
+            LOCK.unlock();
+        }
+    }
+
+    /** Calls the supplier with the PDFium lock held. */
+    public static <T> T call(java.util.function.Supplier<T> action) {
+        LOCK.lock();
+        try {
+            return action.get();
+        } finally {
+            LOCK.unlock();
+        }
+    }
+
+    /**
+     * Wraps a downcall handle so that invoking it acquires the PDFium lock for
+     * the duration of the native call. The returned handle has the same type as
+     * the input, so existing {@code invokeExact} call sites are unaffected.
+     */
+    public static MethodHandle guard(MethodHandle target) {
+        MethodType type = target.type();
+
+        // acquire() runs before target; foldArguments needs a combiner whose
+        // parameters are a prefix of the target's, and () is always a prefix.
+        MethodHandle locked = MethodHandles.foldArguments(target, ACQUIRE);
+
+        // tryFinally's cleanup takes (Throwable[, result], args...) and must
+        // return the target's return type, so adapt release() to that shape.
+        MethodHandle cleanup = type.returnType() == void.class
+                ? MethodHandles.dropArguments(RELEASE, 0, Throwable.class)
+                : releasingIdentity(type.returnType());
+        return MethodHandles.tryFinally(locked, cleanup);
+    }
+
+    /** Builds {@code (Throwable, R) -> { release(); return r; }} for the given R. */
+    private static MethodHandle releasingIdentity(Class<?> returnType) {
+        MethodHandle identity = MethodHandles.identity(returnType);           // (R)R
+        MethodHandle release = MethodHandles.dropArguments(RELEASE, 0, returnType); // (R)void
+        MethodHandle releaseThenReturn = MethodHandles.foldArguments(identity, release); // (R)R
+        return MethodHandles.dropArguments(releaseThenReturn, 0, Throwable.class);      // (Throwable,R)R
+    }
+}

--- a/jpdfium/src/main/java/stirling/software/jpdfium/panama/PageEditBindings.java
+++ b/jpdfium/src/main/java/stirling/software/jpdfium/panama/PageEditBindings.java
@@ -21,15 +21,15 @@ public final class PageEditBindings {
     private PageEditBindings() {}
 
     private static MethodHandle downcall(String name, FunctionDescriptor desc) {
-        return LINKER.downcallHandle(
+        return NativeGuard.guard(LINKER.downcallHandle(
                 LOOKUP.find(name).orElseThrow(() -> new UnsatisfiedLinkError("PDFium symbol not found: " + name)),
-                desc);
+                desc));
     }
 
     private static MethodHandle downcallCritical(String name, FunctionDescriptor desc) {
-        return LINKER.downcallHandle(
+        return NativeGuard.guard(LINKER.downcallHandle(
                 LOOKUP.find(name).orElseThrow(() -> new UnsatisfiedLinkError("PDFium symbol not found: " + name)),
-                desc, Linker.Option.critical(false));
+                desc, Linker.Option.critical(false)));
     }
 
     public static final MethodHandle FPDF_CreateNewDocument = downcall("FPDF_CreateNewDocument",
@@ -288,7 +288,7 @@ public final class PageEditBindings {
 
     private static MethodHandle optionalDowncall(String name, MethodHandle fallback) {
         return LOOKUP.find(name)
-                .map(addr -> LINKER.downcallHandle(addr, FunctionDescriptor.ofVoid(ADDRESS, ADDRESS)))
+                .map(addr -> NativeGuard.guard(LINKER.downcallHandle(addr, FunctionDescriptor.ofVoid(ADDRESS, ADDRESS))))
                 .orElse(fallback);
     }
 }

--- a/jpdfium/src/main/java/stirling/software/jpdfium/panama/PageImportBindings.java
+++ b/jpdfium/src/main/java/stirling/software/jpdfium/panama/PageImportBindings.java
@@ -18,9 +18,9 @@ public final class PageImportBindings {
     private PageImportBindings() {}
 
     private static MethodHandle downcall(String name, FunctionDescriptor desc) {
-        return LINKER.downcallHandle(
+        return NativeGuard.guard(LINKER.downcallHandle(
                 LOOKUP.find(name).orElseThrow(() -> new UnsatisfiedLinkError("PDFium symbol not found: " + name)),
-                desc);
+                desc));
     }
 
     public static final MethodHandle FPDF_ImportPages = downcall("FPDF_ImportPages",

--- a/jpdfium/src/main/java/stirling/software/jpdfium/panama/Pcre2Lib.java
+++ b/jpdfium/src/main/java/stirling/software/jpdfium/panama/Pcre2Lib.java
@@ -24,31 +24,51 @@ public final class Pcre2Lib {
     private Pcre2Lib() {}
 
     public static long compile(String pattern, int flags) {
-        try (Arena a = Arena.ofConfined()) {
-            MemorySegment hSeg = a.allocate(JAVA_LONG);
-            JpdfiumLib.check(JpdfiumH.jpdfium_pcre2_compile(a.allocateFrom(pattern), flags, hSeg), "pcre2Compile");
-            return hSeg.get(JAVA_LONG, 0);
+        NativeGuard.acquire();
+        try {
+            try (Arena a = Arena.ofConfined()) {
+                MemorySegment hSeg = a.allocate(JAVA_LONG);
+                JpdfiumLib.check(JpdfiumH.jpdfium_pcre2_compile(a.allocateFrom(pattern), flags, hSeg), "pcre2Compile");
+                return hSeg.get(JAVA_LONG, 0);
+            }
+        } finally {
+            NativeGuard.release();
         }
     }
 
     public static String matchAll(long patternHandle, String text) {
-        try (Arena a = Arena.ofConfined()) {
-            MemorySegment ptrSeg = a.allocate(ADDRESS);
-            JpdfiumLib.check(JpdfiumH.jpdfium_pcre2_match_all(patternHandle, a.allocateFrom(text), ptrSeg), "pcre2MatchAll");
-            MemorySegment strPtr = ptrSeg.get(ADDRESS, 0);
-            String result = strPtr.reinterpret(Long.MAX_VALUE).getString(0);
-            JpdfiumH.jpdfium_free_string(strPtr);
-            return result;
+        NativeGuard.acquire();
+        try {
+            try (Arena a = Arena.ofConfined()) {
+                MemorySegment ptrSeg = a.allocate(ADDRESS);
+                JpdfiumLib.check(JpdfiumH.jpdfium_pcre2_match_all(patternHandle, a.allocateFrom(text), ptrSeg), "pcre2MatchAll");
+                MemorySegment strPtr = ptrSeg.get(ADDRESS, 0);
+                String result = strPtr.reinterpret(Long.MAX_VALUE).getString(0);
+                JpdfiumH.jpdfium_free_string(strPtr);
+                return result;
+            }
+        } finally {
+            NativeGuard.release();
         }
     }
 
     public static void free(long patternHandle) {
-        JpdfiumH.jpdfium_pcre2_free(patternHandle);
+        NativeGuard.acquire();
+        try {
+            JpdfiumH.jpdfium_pcre2_free(patternHandle);
+        } finally {
+            NativeGuard.release();
+        }
     }
 
     public static boolean luhnValidate(String number) {
-        try (Arena a = Arena.ofConfined()) {
-            return JpdfiumH.jpdfium_luhn_validate(a.allocateFrom(number)) == 1;
+        NativeGuard.acquire();
+        try {
+            try (Arena a = Arena.ofConfined()) {
+                return JpdfiumH.jpdfium_luhn_validate(a.allocateFrom(number)) == 1;
+            }
+        } finally {
+            NativeGuard.release();
         }
     }
 }

--- a/jpdfium/src/main/java/stirling/software/jpdfium/panama/RenderBindings.java
+++ b/jpdfium/src/main/java/stirling/software/jpdfium/panama/RenderBindings.java
@@ -20,15 +20,15 @@ public final class RenderBindings {
     private RenderBindings() {}
 
     private static MethodHandle downcall(String name, FunctionDescriptor desc) {
-        return LINKER.downcallHandle(
+        return NativeGuard.guard(LINKER.downcallHandle(
                 LOOKUP.find(name).orElseThrow(() -> new UnsatisfiedLinkError("PDFium symbol not found: " + name)),
-                desc);
+                desc));
     }
 
     private static MethodHandle downcallCritical(String name, FunctionDescriptor desc) {
-        return LINKER.downcallHandle(
+        return NativeGuard.guard(LINKER.downcallHandle(
                 LOOKUP.find(name).orElseThrow(() -> new UnsatisfiedLinkError("PDFium symbol not found: " + name)),
-                desc, Linker.Option.critical(false));
+                desc, Linker.Option.critical(false)));
     }
 
     // Render flag constants

--- a/jpdfium/src/main/java/stirling/software/jpdfium/panama/RepairLib.java
+++ b/jpdfium/src/main/java/stirling/software/jpdfium/panama/RepairLib.java
@@ -42,39 +42,44 @@ public final class RepairLib {
      * @return repair result with status, output bytes, and diagnostics
      */
     public static RepairResult repair(byte[] input, int flags) {
-        if (input == null || input.length == 0) {
-            return new RepairResult(RepairResult.Status.FAILED, null, "{\"error\":\"empty input\"}");
-        }
-
-        try (Arena arena = Arena.ofConfined()) {
-            MemorySegment inputSeg = arena.allocateFrom(JAVA_BYTE, input);
-            MemorySegment outputPtrSeg = arena.allocate(ADDRESS);
-            MemorySegment outputLenSeg = arena.allocate(JAVA_LONG);
-
-            int rc = JpdfiumH.jpdfium_repair_pdf(
-                    inputSeg, input.length,
-                    outputPtrSeg, outputLenSeg,
-                    flags);
-
-            RepairResult.Status status = switch (rc) {
-                case REPAIR_CLEAN -> RepairResult.Status.CLEAN;
-                case REPAIR_FIXED -> RepairResult.Status.FIXED;
-                case REPAIR_PARTIAL -> RepairResult.Status.PARTIAL;
-                default -> RepairResult.Status.FAILED;
-            };
-
-            byte[] outputBytes = null;
-            if (status != RepairResult.Status.FAILED) {
-                MemorySegment outPtr = outputPtrSeg.get(ADDRESS, 0);
-                long outLen = outputLenSeg.get(JAVA_LONG, 0);
-                if (outLen > 0) {
-                    outputBytes = outPtr.reinterpret(outLen).toArray(JAVA_BYTE);
-                    JpdfiumH.jpdfium_free_buffer(outPtr);
-                }
+        NativeGuard.acquire();
+        try {
+            if (input == null || input.length == 0) {
+                return new RepairResult(RepairResult.Status.FAILED, null, "{\"error\":\"empty input\"}");
             }
 
-            String diagnostics = inspect(input);
-            return new RepairResult(status, outputBytes, diagnostics);
+            try (Arena arena = Arena.ofConfined()) {
+                MemorySegment inputSeg = arena.allocateFrom(JAVA_BYTE, input);
+                MemorySegment outputPtrSeg = arena.allocate(ADDRESS);
+                MemorySegment outputLenSeg = arena.allocate(JAVA_LONG);
+
+                int rc = JpdfiumH.jpdfium_repair_pdf(
+                        inputSeg, input.length,
+                        outputPtrSeg, outputLenSeg,
+                        flags);
+
+                RepairResult.Status status = switch (rc) {
+                    case REPAIR_CLEAN -> RepairResult.Status.CLEAN;
+                    case REPAIR_FIXED -> RepairResult.Status.FIXED;
+                    case REPAIR_PARTIAL -> RepairResult.Status.PARTIAL;
+                    default -> RepairResult.Status.FAILED;
+                };
+
+                byte[] outputBytes = null;
+                if (status != RepairResult.Status.FAILED) {
+                    MemorySegment outPtr = outputPtrSeg.get(ADDRESS, 0);
+                    long outLen = outputLenSeg.get(JAVA_LONG, 0);
+                    if (outLen > 0) {
+                        outputBytes = outPtr.reinterpret(outLen).toArray(JAVA_BYTE);
+                        JpdfiumH.jpdfium_free_buffer(outPtr);
+                    }
+                }
+
+                String diagnostics = inspect(input);
+                return new RepairResult(status, outputBytes, diagnostics);
+            }
+        } finally {
+            NativeGuard.release();
         }
     }
 
@@ -85,22 +90,27 @@ public final class RepairLib {
      * @return JSON diagnostic report
      */
     public static String inspect(byte[] input) {
-        if (input == null || input.length == 0) {
-            return "{\"error\":\"empty input\"}";
-        }
+        NativeGuard.acquire();
+        try {
+            if (input == null || input.length == 0) {
+                return "{\"error\":\"empty input\"}";
+            }
 
-        try (Arena arena = Arena.ofConfined()) {
-            MemorySegment inputSeg = arena.allocateFrom(JAVA_BYTE, input);
-            MemorySegment jsonPtrSeg = arena.allocate(ADDRESS);
+            try (Arena arena = Arena.ofConfined()) {
+                MemorySegment inputSeg = arena.allocateFrom(JAVA_BYTE, input);
+                MemorySegment jsonPtrSeg = arena.allocate(ADDRESS);
 
-            JpdfiumH.jpdfium_repair_inspect(
-                    inputSeg, input.length,
-                    jsonPtrSeg);
+                JpdfiumH.jpdfium_repair_inspect(
+                        inputSeg, input.length,
+                        jsonPtrSeg);
 
-            MemorySegment strPtr = jsonPtrSeg.get(ADDRESS, 0);
-            String result = strPtr.reinterpret(Long.MAX_VALUE).getString(0);
-            JpdfiumH.jpdfium_free_string(strPtr);
-            return result;
+                MemorySegment strPtr = jsonPtrSeg.get(ADDRESS, 0);
+                String result = strPtr.reinterpret(Long.MAX_VALUE).getString(0);
+                JpdfiumH.jpdfium_free_string(strPtr);
+                return result;
+            }
+        } finally {
+            NativeGuard.release();
         }
     }
 
@@ -114,29 +124,34 @@ public final class RepairLib {
      *         fails
      */
     public static byte[] brotliDecode(byte[] compressed) {
-        if (compressed == null || compressed.length == 0)
-            return null;
-
-        try (Arena arena = Arena.ofConfined()) {
-            MemorySegment inputSeg = arena.allocateFrom(JAVA_BYTE, compressed);
-            MemorySegment outPtrSeg = arena.allocate(ADDRESS);
-            MemorySegment outLenSeg = arena.allocate(JAVA_LONG);
-
-            int rc = JpdfiumH.jpdfium_brotli_decode(
-                    inputSeg, compressed.length,
-                    outPtrSeg, outLenSeg);
-
-            if (rc != 0)
-                return null; // ERR_NATIVE or decompress failure
-
-            MemorySegment outPtr = outPtrSeg.get(ADDRESS, 0);
-            long outLen = outLenSeg.get(JAVA_LONG, 0);
-            if (outLen <= 0)
+        NativeGuard.acquire();
+        try {
+            if (compressed == null || compressed.length == 0)
                 return null;
 
-            byte[] result = outPtr.reinterpret(outLen).toArray(JAVA_BYTE);
-            JpdfiumH.jpdfium_free_buffer(outPtr);
-            return result;
+            try (Arena arena = Arena.ofConfined()) {
+                MemorySegment inputSeg = arena.allocateFrom(JAVA_BYTE, compressed);
+                MemorySegment outPtrSeg = arena.allocate(ADDRESS);
+                MemorySegment outLenSeg = arena.allocate(JAVA_LONG);
+
+                int rc = JpdfiumH.jpdfium_brotli_decode(
+                        inputSeg, compressed.length,
+                        outPtrSeg, outLenSeg);
+
+                if (rc != 0)
+                    return null; // ERR_NATIVE or decompress failure
+
+                MemorySegment outPtr = outPtrSeg.get(ADDRESS, 0);
+                long outLen = outLenSeg.get(JAVA_LONG, 0);
+                if (outLen <= 0)
+                    return null;
+
+                byte[] result = outPtr.reinterpret(outLen).toArray(JAVA_BYTE);
+                JpdfiumH.jpdfium_free_buffer(outPtr);
+                return result;
+            }
+        } finally {
+            NativeGuard.release();
         }
     }
 
@@ -147,29 +162,34 @@ public final class RepairLib {
      * @return FlateDecode-compressed bytes, or null if unavailable
      */
     public static byte[] brotliToFlate(byte[] compressed) {
-        if (compressed == null || compressed.length == 0)
-            return null;
-
-        try (Arena arena = Arena.ofConfined()) {
-            MemorySegment inputSeg = arena.allocateFrom(JAVA_BYTE, compressed);
-            MemorySegment outPtrSeg = arena.allocate(ADDRESS);
-            MemorySegment outLenSeg = arena.allocate(JAVA_LONG);
-
-            int rc = JpdfiumH.jpdfium_brotli_to_flate(
-                    inputSeg, compressed.length,
-                    outPtrSeg, outLenSeg);
-
-            if (rc != 0)
+        NativeGuard.acquire();
+        try {
+            if (compressed == null || compressed.length == 0)
                 return null;
 
-            MemorySegment outPtr = outPtrSeg.get(ADDRESS, 0);
-            long outLen = outLenSeg.get(JAVA_LONG, 0);
-            if (outLen <= 0)
-                return null;
+            try (Arena arena = Arena.ofConfined()) {
+                MemorySegment inputSeg = arena.allocateFrom(JAVA_BYTE, compressed);
+                MemorySegment outPtrSeg = arena.allocate(ADDRESS);
+                MemorySegment outLenSeg = arena.allocate(JAVA_LONG);
 
-            byte[] result = outPtr.reinterpret(outLen).toArray(JAVA_BYTE);
-            JpdfiumH.jpdfium_free_buffer(outPtr);
-            return result;
+                int rc = JpdfiumH.jpdfium_brotli_to_flate(
+                        inputSeg, compressed.length,
+                        outPtrSeg, outLenSeg);
+
+                if (rc != 0)
+                    return null;
+
+                MemorySegment outPtr = outPtrSeg.get(ADDRESS, 0);
+                long outLen = outLenSeg.get(JAVA_LONG, 0);
+                if (outLen <= 0)
+                    return null;
+
+                byte[] result = outPtr.reinterpret(outLen).toArray(JAVA_BYTE);
+                JpdfiumH.jpdfium_free_buffer(outPtr);
+                return result;
+            }
+        } finally {
+            NativeGuard.release();
         }
     }
 
@@ -182,45 +202,50 @@ public final class RepairLib {
      * @return repair result with pages recovered
      */
     public static RepairResult pdfioRepair(byte[] input) {
-        if (input == null || input.length == 0) {
-            return new RepairResult(RepairResult.Status.FAILED, null, "{\"error\":\"empty input\"}");
-        }
-
-        try (Arena arena = Arena.ofConfined()) {
-            MemorySegment inputSeg = arena.allocateFrom(JAVA_BYTE, input);
-            MemorySegment outPtrSeg = arena.allocate(ADDRESS);
-            MemorySegment outLenSeg = arena.allocate(JAVA_LONG);
-            MemorySegment pagesSeg = arena.allocate(JAVA_INT);
-
-            int rc = JpdfiumH.jpdfium_pdfio_try_repair(
-                    inputSeg, input.length,
-                    outPtrSeg, outLenSeg, pagesSeg);
-
-            if (rc == ERR_NATIVE) {
-                return new RepairResult(RepairResult.Status.FAILED, null,
-                        "{\"status\":\"unavailable\",\"message\":\"PDFio not linked\"}");
+        NativeGuard.acquire();
+        try {
+            if (input == null || input.length == 0) {
+                return new RepairResult(RepairResult.Status.FAILED, null, "{\"error\":\"empty input\"}");
             }
 
-            RepairResult.Status status = switch (rc) {
-                case REPAIR_CLEAN -> RepairResult.Status.CLEAN;
-                case REPAIR_FIXED -> RepairResult.Status.FIXED;
-                case REPAIR_PARTIAL -> RepairResult.Status.PARTIAL;
-                default -> RepairResult.Status.FAILED;
-            };
+            try (Arena arena = Arena.ofConfined()) {
+                MemorySegment inputSeg = arena.allocateFrom(JAVA_BYTE, input);
+                MemorySegment outPtrSeg = arena.allocate(ADDRESS);
+                MemorySegment outLenSeg = arena.allocate(JAVA_LONG);
+                MemorySegment pagesSeg = arena.allocate(JAVA_INT);
 
-            byte[] outputBytes = null;
-            if (status != RepairResult.Status.FAILED) {
-                MemorySegment outPtr = outPtrSeg.get(ADDRESS, 0);
-                long outLen = outLenSeg.get(JAVA_LONG, 0);
-                if (outLen > 0) {
-                    outputBytes = outPtr.reinterpret(outLen).toArray(JAVA_BYTE);
-                    JpdfiumH.jpdfium_free_buffer(outPtr);
+                int rc = JpdfiumH.jpdfium_pdfio_try_repair(
+                        inputSeg, input.length,
+                        outPtrSeg, outLenSeg, pagesSeg);
+
+                if (rc == ERR_NATIVE) {
+                    return new RepairResult(RepairResult.Status.FAILED, null,
+                            "{\"status\":\"unavailable\",\"message\":\"PDFio not linked\"}");
                 }
-            }
 
-            int pagesRecovered = pagesSeg.get(JAVA_INT, 0);
-            String diag = "{\"source\":\"pdfio\",\"pages_recovered\":" + pagesRecovered + "}";
-            return new RepairResult(status, outputBytes, diag);
+                RepairResult.Status status = switch (rc) {
+                    case REPAIR_CLEAN -> RepairResult.Status.CLEAN;
+                    case REPAIR_FIXED -> RepairResult.Status.FIXED;
+                    case REPAIR_PARTIAL -> RepairResult.Status.PARTIAL;
+                    default -> RepairResult.Status.FAILED;
+                };
+
+                byte[] outputBytes = null;
+                if (status != RepairResult.Status.FAILED) {
+                    MemorySegment outPtr = outPtrSeg.get(ADDRESS, 0);
+                    long outLen = outLenSeg.get(JAVA_LONG, 0);
+                    if (outLen > 0) {
+                        outputBytes = outPtr.reinterpret(outLen).toArray(JAVA_BYTE);
+                        JpdfiumH.jpdfium_free_buffer(outPtr);
+                    }
+                }
+
+                int pagesRecovered = pagesSeg.get(JAVA_INT, 0);
+                String diag = "{\"source\":\"pdfio\",\"pages_recovered\":" + pagesRecovered + "}";
+                return new RepairResult(status, outputBytes, diag);
+            }
+        } finally {
+            NativeGuard.release();
         }
     }
 
@@ -234,21 +259,26 @@ public final class RepairLib {
      * @return JSON validation result, or null if lcms2 is unavailable
      */
     public static String validateIccProfile(byte[] profileData, int expectedComponents) {
-        if (profileData == null || profileData.length == 0)
-            return null;
+        NativeGuard.acquire();
+        try {
+            if (profileData == null || profileData.length == 0)
+                return null;
 
-        try (Arena arena = Arena.ofConfined()) {
-            MemorySegment dataSeg = arena.allocateFrom(JAVA_BYTE, profileData);
-            MemorySegment jsonPtrSeg = arena.allocate(ADDRESS);
+            try (Arena arena = Arena.ofConfined()) {
+                MemorySegment dataSeg = arena.allocateFrom(JAVA_BYTE, profileData);
+                MemorySegment jsonPtrSeg = arena.allocate(ADDRESS);
 
-            int rc = JpdfiumH.jpdfium_validate_icc_profile(
-                    dataSeg, profileData.length,
-                    expectedComponents, jsonPtrSeg);
+                int rc = JpdfiumH.jpdfium_validate_icc_profile(
+                        dataSeg, profileData.length,
+                        expectedComponents, jsonPtrSeg);
 
-            MemorySegment strPtr = jsonPtrSeg.get(ADDRESS, 0);
-            String result = strPtr.reinterpret(Long.MAX_VALUE).getString(0);
-            JpdfiumH.jpdfium_free_string(strPtr);
-            return result;
+                MemorySegment strPtr = jsonPtrSeg.get(ADDRESS, 0);
+                String result = strPtr.reinterpret(Long.MAX_VALUE).getString(0);
+                JpdfiumH.jpdfium_free_string(strPtr);
+                return result;
+            }
+        } finally {
+            NativeGuard.release();
         }
     }
 
@@ -259,24 +289,29 @@ public final class RepairLib {
      * @return profile bytes, or null if lcms2 is unavailable
      */
     public static byte[] generateReplacementIcc(int numComponents) {
-        try (Arena arena = Arena.ofConfined()) {
-            MemorySegment outPtrSeg = arena.allocate(ADDRESS);
-            MemorySegment outLenSeg = arena.allocate(JAVA_LONG);
+        NativeGuard.acquire();
+        try {
+            try (Arena arena = Arena.ofConfined()) {
+                MemorySegment outPtrSeg = arena.allocate(ADDRESS);
+                MemorySegment outLenSeg = arena.allocate(JAVA_LONG);
 
-            int rc = JpdfiumH.jpdfium_generate_replacement_icc(
-                    numComponents, outPtrSeg, outLenSeg);
+                int rc = JpdfiumH.jpdfium_generate_replacement_icc(
+                        numComponents, outPtrSeg, outLenSeg);
 
-            if (rc != 0)
-                return null;
+                if (rc != 0)
+                    return null;
 
-            MemorySegment outPtr = outPtrSeg.get(ADDRESS, 0);
-            long outLen = outLenSeg.get(JAVA_LONG, 0);
-            if (outLen <= 0)
-                return null;
+                MemorySegment outPtr = outPtrSeg.get(ADDRESS, 0);
+                long outLen = outLenSeg.get(JAVA_LONG, 0);
+                if (outLen <= 0)
+                    return null;
 
-            byte[] result = outPtr.reinterpret(outLen).toArray(JAVA_BYTE);
-            JpdfiumH.jpdfium_free_buffer(outPtr);
-            return result;
+                byte[] result = outPtr.reinterpret(outLen).toArray(JAVA_BYTE);
+                JpdfiumH.jpdfium_free_buffer(outPtr);
+                return result;
+            }
+        } finally {
+            NativeGuard.release();
         }
     }
 
@@ -287,20 +322,25 @@ public final class RepairLib {
      * @return JSON validation result, or null if OpenJPEG is unavailable
      */
     public static String validateJpxStream(byte[] jpxData) {
-        if (jpxData == null || jpxData.length == 0)
-            return null;
+        NativeGuard.acquire();
+        try {
+            if (jpxData == null || jpxData.length == 0)
+                return null;
 
-        try (Arena arena = Arena.ofConfined()) {
-            MemorySegment dataSeg = arena.allocateFrom(JAVA_BYTE, jpxData);
-            MemorySegment jsonPtrSeg = arena.allocate(ADDRESS);
+            try (Arena arena = Arena.ofConfined()) {
+                MemorySegment dataSeg = arena.allocateFrom(JAVA_BYTE, jpxData);
+                MemorySegment jsonPtrSeg = arena.allocate(ADDRESS);
 
-            int rc = JpdfiumH.jpdfium_validate_jpx_stream(
-                    dataSeg, jpxData.length, jsonPtrSeg);
+                int rc = JpdfiumH.jpdfium_validate_jpx_stream(
+                        dataSeg, jpxData.length, jsonPtrSeg);
 
-            MemorySegment strPtr = jsonPtrSeg.get(ADDRESS, 0);
-            String result = strPtr.reinterpret(Long.MAX_VALUE).getString(0);
-            JpdfiumH.jpdfium_free_string(strPtr);
-            return result;
+                MemorySegment strPtr = jsonPtrSeg.get(ADDRESS, 0);
+                String result = strPtr.reinterpret(Long.MAX_VALUE).getString(0);
+                JpdfiumH.jpdfium_free_string(strPtr);
+                return result;
+            }
+        } finally {
+            NativeGuard.release();
         }
     }
 
@@ -324,18 +364,23 @@ public final class RepairLib {
      *         success
      */
     public static RepairResult rustRepair(byte[] input) {
-        if (input == null || input.length == 0) {
-            return new RepairResult(RepairResult.Status.FAILED, null,
-                    "{\"error\":\"empty input\"}");
-        }
+        NativeGuard.acquire();
+        try {
+            if (input == null || input.length == 0) {
+                return new RepairResult(RepairResult.Status.FAILED, null,
+                        "{\"error\":\"empty input\"}");
+            }
 
-        byte[] repaired = RustBridgeBindings.rustRepairLopdf(input);
-        if (repaired != null && repaired.length > 0) {
-            String diag = "{\"source\":\"rust-lopdf\",\"status\":\"fixed\"}";
-            return new RepairResult(RepairResult.Status.FIXED, repaired, diag);
+            byte[] repaired = RustBridgeBindings.rustRepairLopdf(input);
+            if (repaired != null && repaired.length > 0) {
+                String diag = "{\"source\":\"rust-lopdf\",\"status\":\"fixed\"}";
+                return new RepairResult(RepairResult.Status.FIXED, repaired, diag);
+            }
+            return new RepairResult(RepairResult.Status.FAILED, null,
+                    "{\"source\":\"rust-lopdf\",\"status\":\"failed\"}");
+        } finally {
+            NativeGuard.release();
         }
-        return new RepairResult(RepairResult.Status.FAILED, null,
-                "{\"source\":\"rust-lopdf\",\"status\":\"failed\"}");
     }
 
     /**
@@ -345,32 +390,37 @@ public final class RepairLib {
      * @return raw pixel bytes (interleaved RGB/Gray/CMYK), or null on failure
      */
     public static byte[] jpxToRaw(byte[] jpxData) {
-        if (jpxData == null || jpxData.length == 0)
-            return null;
-
-        try (Arena arena = Arena.ofConfined()) {
-            MemorySegment dataSeg = arena.allocateFrom(JAVA_BYTE, jpxData);
-            MemorySegment outPtrSeg = arena.allocate(ADDRESS);
-            MemorySegment outLenSeg = arena.allocate(JAVA_LONG);
-            MemorySegment wSeg = arena.allocate(JAVA_INT);
-            MemorySegment hSeg = arena.allocate(JAVA_INT);
-            MemorySegment cSeg = arena.allocate(JAVA_INT);
-
-            int rc = JpdfiumH.jpdfium_jpx_to_raw(
-                    dataSeg, jpxData.length,
-                    outPtrSeg, outLenSeg, wSeg, hSeg, cSeg);
-
-            if (rc != 0)
+        NativeGuard.acquire();
+        try {
+            if (jpxData == null || jpxData.length == 0)
                 return null;
 
-            MemorySegment outPtr = outPtrSeg.get(ADDRESS, 0);
-            long outLen = outLenSeg.get(JAVA_LONG, 0);
-            if (outLen <= 0)
-                return null;
+            try (Arena arena = Arena.ofConfined()) {
+                MemorySegment dataSeg = arena.allocateFrom(JAVA_BYTE, jpxData);
+                MemorySegment outPtrSeg = arena.allocate(ADDRESS);
+                MemorySegment outLenSeg = arena.allocate(JAVA_LONG);
+                MemorySegment wSeg = arena.allocate(JAVA_INT);
+                MemorySegment hSeg = arena.allocate(JAVA_INT);
+                MemorySegment cSeg = arena.allocate(JAVA_INT);
 
-            byte[] result = outPtr.reinterpret(outLen).toArray(JAVA_BYTE);
-            JpdfiumH.jpdfium_free_buffer(outPtr);
-            return result;
+                int rc = JpdfiumH.jpdfium_jpx_to_raw(
+                        dataSeg, jpxData.length,
+                        outPtrSeg, outLenSeg, wSeg, hSeg, cSeg);
+
+                if (rc != 0)
+                    return null;
+
+                MemorySegment outPtr = outPtrSeg.get(ADDRESS, 0);
+                long outLen = outLenSeg.get(JAVA_LONG, 0);
+                if (outLen <= 0)
+                    return null;
+
+                byte[] result = outPtr.reinterpret(outLen).toArray(JAVA_BYTE);
+                JpdfiumH.jpdfium_free_buffer(outPtr);
+                return result;
+            }
+        } finally {
+            NativeGuard.release();
         }
     }
 }

--- a/jpdfium/src/main/java/stirling/software/jpdfium/panama/RustBridgeBindings.java
+++ b/jpdfium/src/main/java/stirling/software/jpdfium/panama/RustBridgeBindings.java
@@ -73,7 +73,7 @@ public final class RustBridgeBindings {
         if (sym.isEmpty()) {
             return null;
         }
-        return LINKER.downcallHandle(sym.get(), desc);
+        return NativeGuard.guard(LINKER.downcallHandle(sym.get(), desc));
     }
 
     /** {@code int32_t jpdfium_rust_compress_pdf(input, input_len, out_ptr, out_len, iters)} */

--- a/jpdfium/src/main/java/stirling/software/jpdfium/panama/SignatureBindings.java
+++ b/jpdfium/src/main/java/stirling/software/jpdfium/panama/SignatureBindings.java
@@ -18,15 +18,15 @@ public final class SignatureBindings {
     private SignatureBindings() {}
 
     private static MethodHandle downcall(String name, FunctionDescriptor desc) {
-        return LINKER.downcallHandle(
+        return NativeGuard.guard(LINKER.downcallHandle(
                 LOOKUP.find(name).orElseThrow(() -> new UnsatisfiedLinkError("PDFium symbol not found: " + name)),
-                desc);
+                desc));
     }
 
     private static MethodHandle downcallCritical(String name, FunctionDescriptor desc) {
-        return LINKER.downcallHandle(
+        return NativeGuard.guard(LINKER.downcallHandle(
                 LOOKUP.find(name).orElseThrow(() -> new UnsatisfiedLinkError("PDFium symbol not found: " + name)),
-                desc, Linker.Option.critical(false));
+                desc, Linker.Option.critical(false)));
     }
 
     public static final MethodHandle FPDF_GetSignatureCount = downcallCritical("FPDF_GetSignatureCount",

--- a/jpdfium/src/main/java/stirling/software/jpdfium/panama/StructureBindings.java
+++ b/jpdfium/src/main/java/stirling/software/jpdfium/panama/StructureBindings.java
@@ -18,15 +18,15 @@ public final class StructureBindings {
     private StructureBindings() {}
 
     private static MethodHandle downcall(String name, FunctionDescriptor desc) {
-        return LINKER.downcallHandle(
+        return NativeGuard.guard(LINKER.downcallHandle(
                 LOOKUP.find(name).orElseThrow(() -> new UnsatisfiedLinkError("PDFium symbol not found: " + name)),
-                desc);
+                desc));
     }
 
     private static MethodHandle downcallCritical(String name, FunctionDescriptor desc) {
-        return LINKER.downcallHandle(
+        return NativeGuard.guard(LINKER.downcallHandle(
                 LOOKUP.find(name).orElseThrow(() -> new UnsatisfiedLinkError("PDFium symbol not found: " + name)),
-                desc, Linker.Option.critical(false));
+                desc, Linker.Option.critical(false)));
     }
 
     public static final MethodHandle FPDF_StructTree_GetForPage = downcall("FPDF_StructTree_GetForPage",

--- a/jpdfium/src/main/java/stirling/software/jpdfium/panama/TextPageBindings.java
+++ b/jpdfium/src/main/java/stirling/software/jpdfium/panama/TextPageBindings.java
@@ -18,15 +18,15 @@ public final class TextPageBindings {
     private TextPageBindings() {}
 
     private static MethodHandle downcall(String name, FunctionDescriptor desc) {
-        return LINKER.downcallHandle(
+        return NativeGuard.guard(LINKER.downcallHandle(
                 LOOKUP.find(name).orElseThrow(() -> new UnsatisfiedLinkError("PDFium symbol not found: " + name)),
-                desc);
+                desc));
     }
 
     private static MethodHandle downcallCritical(String name, FunctionDescriptor desc) {
-        return LINKER.downcallHandle(
+        return NativeGuard.guard(LINKER.downcallHandle(
                 LOOKUP.find(name).orElseThrow(() -> new UnsatisfiedLinkError("PDFium symbol not found: " + name)),
-                desc, Linker.Option.critical(false));
+                desc, Linker.Option.critical(false)));
     }
 
     /** Load a text page from a page handle. Returns FPDF_TEXTPAGE. */

--- a/jpdfium/src/main/java/stirling/software/jpdfium/panama/ThumbnailBindings.java
+++ b/jpdfium/src/main/java/stirling/software/jpdfium/panama/ThumbnailBindings.java
@@ -18,15 +18,15 @@ public final class ThumbnailBindings {
     private ThumbnailBindings() {}
 
     private static MethodHandle downcall(String name, FunctionDescriptor desc) {
-        return LINKER.downcallHandle(
+        return NativeGuard.guard(LINKER.downcallHandle(
                 LOOKUP.find(name).orElseThrow(() -> new UnsatisfiedLinkError("PDFium symbol not found: " + name)),
-                desc);
+                desc));
     }
 
     private static MethodHandle downcallCritical(String name, FunctionDescriptor desc) {
-        return LINKER.downcallHandle(
+        return NativeGuard.guard(LINKER.downcallHandle(
                 LOOKUP.find(name).orElseThrow(() -> new UnsatisfiedLinkError("PDFium symbol not found: " + name)),
-                desc, Linker.Option.critical(false));
+                desc, Linker.Option.critical(false)));
     }
 
     public static final MethodHandle FPDFPage_GetDecodedThumbnailData = downcall("FPDFPage_GetDecodedThumbnailData",

--- a/jpdfium/src/main/java/stirling/software/jpdfium/panama/WebLinkBindings.java
+++ b/jpdfium/src/main/java/stirling/software/jpdfium/panama/WebLinkBindings.java
@@ -18,15 +18,15 @@ public final class WebLinkBindings {
     private WebLinkBindings() {}
 
     private static MethodHandle downcall(String name, FunctionDescriptor desc) {
-        return LINKER.downcallHandle(
+        return NativeGuard.guard(LINKER.downcallHandle(
                 LOOKUP.find(name).orElseThrow(() -> new UnsatisfiedLinkError("PDFium symbol not found: " + name)),
-                desc);
+                desc));
     }
 
     private static MethodHandle downcallCritical(String name, FunctionDescriptor desc) {
-        return LINKER.downcallHandle(
+        return NativeGuard.guard(LINKER.downcallHandle(
                 LOOKUP.find(name).orElseThrow(() -> new UnsatisfiedLinkError("PDFium symbol not found: " + name)),
-                desc, Linker.Option.critical(false));
+                desc, Linker.Option.critical(false)));
     }
 
     /** Load web links from a text page handle. Returns FPDF_PAGELINK handle. */

--- a/jpdfium/src/main/java/stirling/software/jpdfium/panama/XmpLib.java
+++ b/jpdfium/src/main/java/stirling/software/jpdfium/panama/XmpLib.java
@@ -15,31 +15,46 @@ public final class XmpLib {
     private XmpLib() {}
 
     public static int redactPatterns(long doc, String[] patterns) {
-        if (patterns == null || patterns.length == 0) return 0;
-        try (Arena a = Arena.ofConfined()) {
-            MemorySegment ptrs = a.allocate(ADDRESS, patterns.length);
-            for (int i = 0; i < patterns.length; i++) {
-                ptrs.setAtIndex(ADDRESS, i, a.allocateFrom(patterns[i]));
+        NativeGuard.acquire();
+        try {
+            if (patterns == null || patterns.length == 0) return 0;
+            try (Arena a = Arena.ofConfined()) {
+                MemorySegment ptrs = a.allocate(ADDRESS, patterns.length);
+                for (int i = 0; i < patterns.length; i++) {
+                    ptrs.setAtIndex(ADDRESS, i, a.allocateFrom(patterns[i]));
+                }
+                MemorySegment countSeg = a.allocate(JAVA_INT);
+                JpdfiumLib.check(JpdfiumH.jpdfium_xmp_redact_patterns(doc, ptrs, patterns.length, countSeg),
+                        "xmpRedactPatterns");
+                return countSeg.get(JAVA_INT, 0);
             }
-            MemorySegment countSeg = a.allocate(JAVA_INT);
-            JpdfiumLib.check(JpdfiumH.jpdfium_xmp_redact_patterns(doc, ptrs, patterns.length, countSeg),
-                    "xmpRedactPatterns");
-            return countSeg.get(JAVA_INT, 0);
+        } finally {
+            NativeGuard.release();
         }
     }
 
     public static void metadataStrip(long doc, String[] keys) {
-        if (keys == null || keys.length == 0) return;
-        try (Arena a = Arena.ofConfined()) {
-            MemorySegment ptrs = a.allocate(ADDRESS, keys.length);
-            for (int i = 0; i < keys.length; i++) {
-                ptrs.setAtIndex(ADDRESS, i, a.allocateFrom(keys[i]));
+        NativeGuard.acquire();
+        try {
+            if (keys == null || keys.length == 0) return;
+            try (Arena a = Arena.ofConfined()) {
+                MemorySegment ptrs = a.allocate(ADDRESS, keys.length);
+                for (int i = 0; i < keys.length; i++) {
+                    ptrs.setAtIndex(ADDRESS, i, a.allocateFrom(keys[i]));
+                }
+                JpdfiumLib.check(JpdfiumH.jpdfium_metadata_strip(doc, ptrs, keys.length), "metadataStrip");
             }
-            JpdfiumLib.check(JpdfiumH.jpdfium_metadata_strip(doc, ptrs, keys.length), "metadataStrip");
+        } finally {
+            NativeGuard.release();
         }
     }
 
     public static void metadataStripAll(long doc) {
-        JpdfiumLib.check(JpdfiumH.jpdfium_metadata_strip_all(doc), "metadataStripAll");
+        NativeGuard.acquire();
+        try {
+            JpdfiumLib.check(JpdfiumH.jpdfium_metadata_strip_all(doc), "metadataStripAll");
+        } finally {
+            NativeGuard.release();
+        }
     }
 }

--- a/jpdfium/src/test/java/stirling/software/jpdfium/ConcurrencyTest.java
+++ b/jpdfium/src/test/java/stirling/software/jpdfium/ConcurrencyTest.java
@@ -1,0 +1,119 @@
+package stirling.software.jpdfium;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Regression tests for concurrent use of PDFium.
+ *
+ * <p>PDFium keeps process-wide mutable state (font manager and cache, page
+ * module, parser tables) that is shared by every open document, so two threads
+ * calling into it simultaneously corrupt that state even when each owns a
+ * completely independent document. Before the {@code NativeGuard} serialisation
+ * these tests segfaulted the JVM within a second, or - in the quieter failure
+ * mode - reported the great majority of perfectly valid documents as corrupt.
+ *
+ * <p>A regression here does not fail cleanly: it either crashes the JVM outright
+ * (killing the whole test run) or shows up as a nonzero error count below.
+ */
+class ConcurrencyTest {
+
+    private static final int THREADS = 8;
+    private static final int ITERATIONS = 40;
+
+    private static byte[] pdfBytes() throws IOException {
+        return ConcurrencyTest.class.getResourceAsStream("/pdfs/general/minimal.pdf").readAllBytes();
+    }
+
+    /** Runs {@code body} on THREADS threads and returns the first failure, if any. */
+    private static Throwable runConcurrently(Runnable body) throws InterruptedException {
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(THREADS);
+        List<Throwable> failures = new ArrayList<>();
+
+        for (int t = 0; t < THREADS; t++) {
+            Thread thread = new Thread(() -> {
+                try {
+                    start.await();
+                    for (int i = 0; i < ITERATIONS; i++) {
+                        body.run();
+                    }
+                } catch (Throwable e) {
+                    synchronized (failures) {
+                        failures.add(e);
+                    }
+                } finally {
+                    done.countDown();
+                }
+            }, "concurrency-test-" + t);
+            thread.setDaemon(true);
+            thread.start();
+        }
+
+        start.countDown();
+        assertTrue(done.await(120, TimeUnit.SECONDS), "workers did not finish - possible deadlock");
+        synchronized (failures) {
+            return failures.isEmpty() ? null : failures.get(0);
+        }
+    }
+
+    @Test
+    @Timeout(180)
+    void independentDocumentsOpenConcurrently() throws Exception {
+        byte[] src = pdfBytes();
+        // The quiet failure mode: unsynchronised concurrent loads made PDFium
+        // reject valid input, so assert on a clean open rather than survival.
+        Throwable failure = runConcurrently(() -> {
+            try (PdfDocument doc = PdfDocument.open(src.clone())) {
+                assertEquals(3, doc.pageCount());
+            }
+        });
+        assertNull(failure, () -> "concurrent open failed: " + failure);
+    }
+
+    @Test
+    @Timeout(180)
+    void independentDocumentsRenderAndExtractConcurrently() throws Exception {
+        byte[] src = pdfBytes();
+
+        String expectedText;
+        try (PdfDocument doc = PdfDocument.open(src.clone()); PdfPage page = doc.page(0)) {
+            expectedText = page.extractTextJson();
+        }
+
+        AtomicInteger mismatches = new AtomicInteger();
+        Throwable failure = runConcurrently(() -> {
+            try (PdfDocument doc = PdfDocument.open(src.clone())) {
+                try (PdfPage page = doc.page(0)) {
+                    page.renderAt(72);
+                    if (!expectedText.equals(page.extractTextJson())) {
+                        mismatches.incrementAndGet();
+                    }
+                }
+                doc.saveBytes();
+            }
+        });
+
+        assertNull(failure, () -> "concurrent render/extract failed: " + failure);
+        assertEquals(0, mismatches.get(), "text extraction returned different results under concurrency");
+    }
+
+    @Test
+    @Timeout(60)
+    void closingTheSameDocumentTwiceIsSafe() throws Exception {
+        // close() must be atomic: a lost race double-frees the native handle.
+        PdfDocument doc = PdfDocument.open(pdfBytes());
+        doc.close();
+        assertDoesNotThrow(doc::close);
+        assertThrows(IllegalStateException.class, doc::pageCount);
+    }
+}


### PR DESCRIPTION
## Problem

PDFium is not thread-safe, including across independent documents. The library's own docs contradicted each other on this:

- `PdfDocument` javadoc: *"Multiple independent PdfDocument instances on separate threads are safe."*
- `PdfPipeline` javadoc: *"PDFium's internal state is not thread-safe - even across independent document instances. All PDFium native calls must be serialized."*

`PdfPipeline` was right. Its `PDFIUM_LOCK` was an opt-in convention used only inside the pipeline; `PdfDocument`, `PdfPage`, `JpdfiumLib` and the `doc/*` helpers did no locking at all, so any caller driving PDFium from more than one thread (a Spring MVC app serving concurrent requests, for example) ran unsynchronised.

Reproduced against released 1.0.2 on **Windows 11** and **Ubuntu 24.04 in Docker** - not OS-specific:

| workload | result |
|---|---|
| 8 threads, independent documents | `EXCEPTION_ACCESS_VIOLATION` in `pdfium.dll` / `SIGSEGV` in `libpdfium.so` + `double free or corruption`, 3/3 runs, within ~1s |
| 2 threads | also crashes |

The quieter failure mode matters more, because it is hit before the crash. Concurrent document open, nothing else:

| threads | ok | errors |
|---|---|---|
| 1 | 300 | **0** |
| 2 | 76 | **524** |
| 8 | 37 | **2363** |

All `PdfCorruptException: Invalid/corrupt PDF` on a valid file. Under load the library rejects the great majority of good documents.

## Cause

PDFium keeps process-wide mutable state - font manager and cache, page module, parser tables, the global last-error slot - shared by every open document, so two threads inside it at once corrupt that state regardless of document independence. The bridge adds its own: unsynchronised lazily-initialised `FT_Library` globals in `jpdfium_advanced.cpp` and `jpdfium_redact.cpp`.

## Change

New `panama/NativeGuard`: a single `ReentrantLock`, plus `guard(MethodHandle)` which wraps a downcall handle via `foldArguments` + `tryFinally`. The wrapper preserves the handle's type, so the ~339 existing `invokeExact` call sites are untouched.

Applied at both choke points, so callers get safety by default:

- all 20 `*Bindings` classes - `downcall` / `downcallCritical` / `downcallOptional` / `optionalDowncall` helpers return guarded handles
- the 9 classes that call the generated `JpdfiumH` directly (`JpdfiumLib`, `FontLib`, `GlyphLib`, `XmpLib`, `IcuLib`, `Pcre2Lib`, `FlashTextLib`, `RepairLib`, `doc/PdfPageImporter`) - public methods acquire/release around the native work
- `FontLib.jpdfium_strip_fonts`, the one handle built outside a helper

The lock is reentrant because higher-level helpers routinely make several guarded calls while already holding it. `PdfVersionConverter`'s `FPDF_FILEWRITE` upcall runs on the lock-holding thread and writes to a `ThreadLocal` buffer, so it does not deadlock.

Two further races the lock does not cover, fixed here too:

- `PdfDocument.close()` / `PdfPage.close()` used non-atomic check-then-set on a `volatile boolean`, so a lost race double-freed the native handle. Now `AtomicBoolean.compareAndSet`.
- The shutdown hook called `FPDF_DestroyLibrary` without waiting for in-flight calls. Now takes the guard.

`PdfPipeline.PDFIUM_LOCK` is deprecated rather than removed, so existing `synchronized (PDFIUM_LOCK)` blocks keep compiling. They are now redundant but harmless.

## Verification

- New `ConcurrencyTest` covering concurrent open, concurrent render/extract with output comparison against a single-threaded baseline, and double-close.
- 16 threads x 200 rounds, no caller-side locking: **3200/3200 ok, 0 errors, 0 text mismatches, 3/3 runs on both Windows and Linux**. All five isolated operations (open, page open, render, text, save) clean at 16 threads.
- Full suite: 376 tests, 2 failures - `PiiRedactorTest.fullPipelineWithAllFeatures` and `S06Test.runS06`, both verified failing on unmodified `main` (7721f07).

## Cost

Throughput ceiling is roughly one thread's worth of PDFium time (~215-290 rounds/s, flat from 1 to 16 threads). That is not a regression: PDFium work was never actually running in parallel, it was corrupting. Java-side work still overlaps outside the lock.

## Note for the release

Javadoc references `1.0.4` as the version introducing this, so the release tag should be `v1.0.4` - `1.0.3` is already published.