### PR TITLE
Speed up redaction pipeline (raw-text PII pre-scan, lazy grapheme pass)

### DIFF
--- a/jpdfium/src/main/java/stirling/software/jpdfium/redact/PdfRedactor.java
+++ b/jpdfium/src/main/java/stirling/software/jpdfium/redact/PdfRedactor.java
@@ -9,8 +9,7 @@ import stirling.software.jpdfium.redact.pii.EntityRedactor;
 import stirling.software.jpdfium.redact.pii.GlyphRedactor;
 import stirling.software.jpdfium.redact.pii.PatternEngine;
 import stirling.software.jpdfium.redact.pii.XmpRedactor;
-import stirling.software.jpdfium.text.PdfTextExtractor;
-import stirling.software.jpdfium.text.PageText;
+import stirling.software.jpdfium.text.PdfBoundedText;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -130,8 +129,7 @@ public final class PdfRedactor {
         if (!options.piiPatterns().isEmpty()) {
             try (PatternEngine engine = PatternEngine.create(options.piiPatterns())) {
                 for (int i = 0; i < totalPages; i++) {
-                    PageText pageText = PdfTextExtractor.extractPage(doc, i);
-                    String text = pageText.plainText();
+                    String text = extractPageText(doc, i);
                     if (text.isEmpty()) continue;
 
                     List<PatternEngine.Match> matches = engine.findAll(text);
@@ -280,8 +278,7 @@ public final class PdfRedactor {
             }
 
             for (int i = 0; i < totalPages; i++) {
-                PageText pageText = PdfTextExtractor.extractPage(doc, i);
-                String text = pageText.plainText();
+                String text = extractPageText(doc, i);
                 if (text.isEmpty()) continue;
 
                 String json = FlashTextLib.find(handle, text);
@@ -316,6 +313,21 @@ public final class PdfRedactor {
         }
 
         return total;
+    }
+
+    /**
+     * Raw text of one page via a single {@code FPDFText_GetText} dump.
+     *
+     * <p>The PII/NER pre-scan only needs the raw character stream - building
+     * the structured char/line/word model (per-char JSON round-trip plus
+     * geometry parsing) is wasted work here. This matches the unnormalized
+     * character stream the native redaction pass scans, so matches found here
+     * are the same matches the native pass verifies.
+     */
+    private static String extractPageText(PdfDocument doc, int pageIndex) {
+        try (PdfPage page = doc.page(pageIndex)) {
+            return PdfBoundedText.extractAll(page.rawHandle());
+        }
     }
 
     private static String escapeForRedact(String text, boolean regexMode) {

--- a/jpdfium/src/test/java/stirling/software/jpdfium/samples/S95_RedactPipelinePerf.java
+++ b/jpdfium/src/test/java/stirling/software/jpdfium/samples/S95_RedactPipelinePerf.java
@@ -1,0 +1,244 @@
+package stirling.software.jpdfium.samples;
+
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.common.PDRectangle;
+import org.apache.pdfbox.pdmodel.font.PDType1Font;
+import org.apache.pdfbox.pdmodel.font.Standard14Fonts;
+import stirling.software.jpdfium.PdfDocument;
+import stirling.software.jpdfium.redact.PdfRedactor;
+import stirling.software.jpdfium.redact.RedactOptions;
+import stirling.software.jpdfium.redact.RedactResult;
+import stirling.software.jpdfium.redact.pii.PiiCategory;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+
+/**
+ * SAMPLE 95 - Redaction pipeline performance harness.
+ *
+ * <p>Measures end-to-end {@link PdfRedactor} cost (mark+scan+Object Fission
+ * + audit + serialize) on a fresh synthetic multi-page document per iteration,
+ * so every iteration does real work. A pure {@code open+save} baseline is
+ * subtracted so the reported cost isolates the redaction pipeline from
+ * parse/serialize overhead. Reported per operation: p50/p95/p99/max in ms.
+ *
+ * <p>Results are written to {@code samples-output/S95_redact-pipeline-perf/perf.csv}.
+ *
+ * <p><strong>VM Options required in IntelliJ:</strong>
+ * {@code --enable-native-access=ALL-UNNAMED}
+ */
+public class S95_RedactPipelinePerf {
+
+    private static final int PAGES = 30;
+    private static final int WARMUP = 4;
+    private static final int ITERATIONS = 12;
+
+    public static void main(String[] args) throws Exception {
+        SampleBase.ensureNative();
+        Path outDir = SampleBase.out("S95_redact-pipeline-perf");
+        Path csv = outDir.resolve("perf.csv");
+
+        byte[] pdf = generateReportPdf(PAGES);
+        System.out.printf("S95_RedactPerf | %d-page synthetic report PDF (%d bytes)%n",
+                PAGES, pdf.length);
+
+        Sample sample = new Sample(pdf);
+        sample.run("baseline-open-save", pdfBytes -> {
+            try (PdfDocument doc = PdfDocument.open(pdfBytes)) {
+                doc.saveBytes();
+            }
+        });
+        sample.run("redact-words", S95_RedactPipelinePerf::redactWords);
+        sample.run("redact-nomatch", S95_RedactPipelinePerf::redactNoMatch);
+        sample.run("redact-words+pii", S95_RedactPipelinePerf::redactWordsPii);
+        sample.run("redact-words+pii+sanitize", S95_RedactPipelinePerf::redactWordsPiiSanitize);
+        sample.run("redact+normalizeFonts", S95_RedactPipelinePerf::redactNormalizeFonts);
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("op,p50_ms,p95_ms,p99_ms,max_ms,op_cost_p50_ms\n");
+        sample.writeTo(sb);
+
+        Files.writeString(csv, sb.toString(), StandardCharsets.UTF_8);
+        System.out.println(sb);
+        System.out.printf("%nPerf results written to %s%n", csv.toAbsolutePath());
+    }
+
+    private static RedactResult redactWords(byte[] pdf) {
+        RedactOptions opts = RedactOptions.builder()
+                .addWord("Confidential")
+                .addWord("secret")
+                .removeContent(true)
+                .build();
+        return runAndClose(pdf, opts);
+    }
+
+    /** Word absent from the whole document: exercises the full-scan, zero-match path on every page. */
+    private static RedactResult redactNoMatch(byte[] pdf) {
+        RedactOptions opts = RedactOptions.builder()
+                .addWord("zzznomatchzzz")
+                .removeContent(true)
+                .build();
+        return runAndClose(pdf, opts);
+    }
+
+    private static RedactResult redactWordsPii(byte[] pdf) {
+        RedactOptions opts = RedactOptions.builder()
+                .addWord("Confidential")
+                .addWord("secret")
+                .enablePiiPatterns(PiiCategory.select(
+                        PiiCategory.EMAIL, PiiCategory.SSN,
+                        PiiCategory.PHONE, PiiCategory.CREDIT_CARD))
+                .removeContent(true)
+                .build();
+        return runAndClose(pdf, opts);
+    }
+
+    private static RedactResult redactWordsPiiSanitize(byte[] pdf) {
+        RedactOptions opts = RedactOptions.builder()
+                .addWord("Confidential")
+                .addWord("secret")
+                .enablePiiPatterns(PiiCategory.select(
+                        PiiCategory.EMAIL, PiiCategory.SSN,
+                        PiiCategory.PHONE, PiiCategory.CREDIT_CARD))
+                .sanitizeStructure(true)
+                .removeContent(true)
+                .build();
+        return runAndClose(pdf, opts);
+    }
+
+    private static RedactResult redactNormalizeFonts(byte[] pdf) {
+        RedactOptions opts = RedactOptions.builder()
+                .addWord("Confidential")
+                .addWord("secret")
+                .normalizeFonts(true)
+                .removeContent(true)
+                .build();
+        return runAndClose(pdf, opts);
+    }
+
+    /** Runs the pipeline, serializes the result, and closes - mirroring a real caller. */
+    private static RedactResult runAndClose(byte[] pdf, RedactOptions opts) {
+        try (PdfDocument doc = PdfDocument.open(pdf)) {
+            RedactResult result = PdfRedactor.redact(doc, opts);
+            result.document().saveBytes();
+            result.document().close();
+            return result;
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Synthetic content
+    // ------------------------------------------------------------------
+
+    private static byte[] generateReportPdf(int pages) throws Exception {
+        try (PDDocument doc = new PDDocument()) {
+            for (int p = 0; p < pages; p++) {
+                PDPage page = new PDPage(PDRectangle.LETTER);
+                doc.addPage(page);
+                try (PDPageContentStream cs =
+                             new PDPageContentStream(doc, page)) {
+                    cs.setFont(new PDType1Font(Standard14Fonts.FontName.HELVETICA), 11);
+                    float y = 760;
+                    for (int line = 0; line < 22 && y > 40; line++) {
+                        String text = lineText(p, line);
+                        cs.beginText();
+                        cs.newLineAtOffset(56, y);
+                        cs.showText(text);
+                        cs.endText();
+                        y -= 32;
+                    }
+                }
+            }
+            try (ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
+                doc.save(bos);
+                return bos.toByteArray();
+            }
+        }
+    }
+
+    private static String lineText(int page, int line) {
+        String[] filler = {
+                "The quarterly review of the department budget was completed",
+                "All staff must treat the contents of this document as Confidential",
+                "Progress on the Alpha project remains on schedule and under budget",
+                "The 123-45-6789 record was verified against the master ledger",
+                "Contact john.doe@example.com or call (555) 010-9988 for access",
+                "A secret key rotation is planned for the next maintenance window",
+                "Expenses were categorized and reconciled with the general ledger",
+                "The committee approved the new procurement guidelines last month",
+                "Figures from Q3 indicate a steady increase in overall throughput",
+                "Please ensure that all confidential drafts are shredded securely",
+                "Vendor invoices were matched against purchase orders and receipts",
+                "The audit trail shows no unauthorized access during the period",
+                "Deliverables for the upcoming release were frozen this morning",
+                "Card number 4532 1234 5678 9012 was used for the travel booking",
+                "Minutes from the steering group were circulated to all members",
+                "Risk assessment flagged the migration plan as requiring attention",
+                "Employee onboarding documentation was updated for the new year",
+                "The internal wiki now hosts the revised operational playbooks",
+                "Quarterly targets were met despite the temporary staffing gap",
+                "Storage quotas were raised to accommodate the archival backlog",
+                "The final sign-off is pending until the legal review concludes",
+                "Backups are verified nightly and retained for six months",
+        };
+        return filler[(page * 7 + line) % filler.length];
+    }
+
+    // ------------------------------------------------------------------
+    // Harness (fresh document per iteration)
+    // ------------------------------------------------------------------
+
+    private static final class Sample {
+        private final byte[] pdf;
+        private final LinkedHashMap<String, double[]> totals = new LinkedHashMap<>();
+        private double[] baseline;
+
+        interface Op { void run(byte[] pdf) throws Exception; }
+
+        Sample(byte[] pdf) { this.pdf = pdf; }
+
+        void run(String label, Op op) {
+            for (int i = 0; i < WARMUP; i++) {
+                try { op.run(pdf); } catch (Exception e) { throw new RuntimeException(e); }
+            }
+            double[] samples = new double[ITERATIONS];
+            for (int i = 0; i < ITERATIONS; i++) {
+                long t0 = System.nanoTime();
+                try { op.run(pdf); } catch (Exception e) { throw new RuntimeException(e); }
+                samples[i] = (System.nanoTime() - t0) / 1_000_000.0;  // ms
+            }
+            if ("baseline-open-save".equals(label)) baseline = samples; else totals.put(label, samples);
+        }
+
+        void writeTo(StringBuilder sb) {
+            if (baseline == null) return;
+            Arrays.sort(baseline);
+            double base50 = percentile(baseline, 0.50);
+            for (var e : totals.entrySet()) {
+                double[] s = e.getValue();
+                Arrays.sort(s);
+                double p50 = percentile(s, 0.50);
+                double p95 = percentile(s, 0.95);
+                double p99 = percentile(s, 0.99);
+                double max = s[s.length - 1];
+                double opCost50 = Math.max(0, p50 - base50);
+                sb.append(String.format("%s,%.1f,%.1f,%.1f,%.1f,%.1f%n",
+                        e.getKey(), p50, p95, p99, max, opCost50));
+                System.out.printf("%-26s p50=%8.1fms p95=%8.1fms p99=%8.1fms max=%8.1fms"
+                                + "  | pipeline cost vs baseline: %.1fms%n",
+                        e.getKey(), p50, p95, p99, max, opCost50);
+            }
+            System.out.printf("%-26s p50=%8.1fms (open + full serialize only)%n", "baseline", base50);
+        }
+
+        private static double percentile(double[] sorted, double q) {
+            return sorted[(int) Math.round(q * (sorted.length - 1))];
+        }
+    }
+}

--- a/native/bridge/src/jpdfium_redact.cpp
+++ b/native/bridge/src/jpdfium_redact.cpp
@@ -3056,15 +3056,9 @@ int32_t jpdfium_redact_pattern(int64_t page, const char* pattern, uint32_t argb,
 
         // Build the search buffer: NFKC-normalized text (ligature and
         // compatibility characters decomposed) with an index map back to the
-        // original character indices, plus the raw unicode sequence used for
-        // grapheme-cluster boundary alignment.
+        // original character indices.
         std::vector<int> idxMap;
         std::u32string wtext = buildNormalizedText(tp, count, idxMap);
-        std::vector<uint32_t> unicodeSeq;
-        unicodeSeq.reserve(static_cast<size_t>(count));
-        for (int i = 0; i < count; ++i) {
-            unicodeSeq.push_back(FPDFText_GetUnicode(tp, i));
-        }
 
         // Compile the pattern (PCRE2 UTF/UCP, JIT, hardened limits).
         // Sanitize-stage bookkeeping: metadata/outlines/form values containing
@@ -3091,6 +3085,20 @@ int32_t jpdfium_redact_pattern(int64_t page, const char* pattern, uint32_t argb,
 #else
         (void)wtext;
 #endif
+
+        if (matches.empty()) {
+            FPDFText_ClosePage(tp);
+            return JPDFIUM_OK;
+        }
+
+        // Only now build the raw unicode sequence needed for grapheme
+        // alignment - it is a full second per-char pass over the text page,
+        // so zero-match pages (the common case) never pay for it.
+        std::vector<uint32_t> unicodeSeq;
+        unicodeSeq.reserve(static_cast<size_t>(count));
+        for (int i = 0; i < count; ++i) {
+            unicodeSeq.push_back(FPDFText_GetUnicode(tp, i));
+        }
         alignMatchesToGraphemes(tp, unicodeSeq, matches);
 #ifdef JPDFIUM_HAS_HARFBUZZ
         // Snap every span to shaped-cluster boundaries (ligature safety):
@@ -3098,11 +3106,6 @@ int32_t jpdfium_redact_pattern(int64_t page, const char* pattern, uint32_t argb,
         // unrenderable, so the span grows to the whole cluster.
         alignMatchesToShapedClusters(tp, matches);
 #endif
-
-        if (matches.empty()) {
-            FPDFText_ClosePage(tp);
-            return JPDFIUM_OK;
-        }
 
         // Expected surviving-text fingerprint (pre-redaction).
         std::vector<char> redactSet(count, 0);
@@ -3182,15 +3185,9 @@ int32_t jpdfium_redact_words_ex(int64_t page, const char** words, int32_t wordCo
 
         int count = FPDFText_CountChars(tp);
 
-        // Build the search buffer: NFKC-normalized text with an index map,
-        // plus the raw unicode sequence for grapheme boundary alignment.
+        // Build the search buffer: NFKC-normalized text with an index map.
         std::vector<int> idxMap;
         std::u32string wtext = buildNormalizedText(tp, count, idxMap);
-        std::vector<uint32_t> unicodeSeq;
-        unicodeSeq.reserve(static_cast<size_t>(count));
-        for (int i = 0; i < count; ++i) {
-            unicodeSeq.push_back(FPDFText_GetUnicode(tp, i));
-        }
 
         std::vector<TextMatch> matches;
 #ifdef JPDFIUM_HAS_PCRE2
@@ -3261,18 +3258,6 @@ int32_t jpdfium_redact_words_ex(int64_t page, const char** words, int32_t wordCo
 #endif
             }
         }
-        alignMatchesToGraphemes(tp, unicodeSeq, matches);
-#ifdef JPDFIUM_HAS_HARFBUZZ
-        // Snap every span to shaped-cluster boundaries (ligature safety):
-        // a cut inside a shaped cluster would leave the survivor
-        // unrenderable, so the span grows to the whole cluster.
-        alignMatchesToShapedClusters(tp, matches);
-#endif
-        std::vector<char> redactSet(count, 0);
-        for (auto& m : matches)
-            for (int ci : m.charIndices) redactSet[ci] = 1;
-        std::u32string expectedFp = survivingFingerprint(wtext, idxMap, redactSet);
-
         if (matchCount) *matchCount = static_cast<int32_t>(matches.size());
 
         // Every supplied pattern failed to compile: the caller believes the
@@ -3287,6 +3272,26 @@ int32_t jpdfium_redact_words_ex(int64_t page, const char** words, int32_t wordCo
             FPDFText_ClosePage(tp);
             return JPDFIUM_OK;
         }
+
+        // Only now build the raw unicode sequence needed for grapheme
+        // alignment - it is a full second per-char pass over the text page,
+        // so zero-match pages (the common case) never pay for it.
+        std::vector<uint32_t> unicodeSeq;
+        unicodeSeq.reserve(static_cast<size_t>(count));
+        for (int i = 0; i < count; ++i) {
+            unicodeSeq.push_back(FPDFText_GetUnicode(tp, i));
+        }
+        alignMatchesToGraphemes(tp, unicodeSeq, matches);
+#ifdef JPDFIUM_HAS_HARFBUZZ
+        // Snap every span to shaped-cluster boundaries (ligature safety):
+        // a cut inside a shaped cluster would leave the survivor
+        // unrenderable, so the span grows to the whole cluster.
+        alignMatchesToShapedClusters(tp, matches);
+#endif
+        std::vector<char> redactSet(count, 0);
+        for (auto& m : matches)
+            for (int ci : m.charIndices) redactSet[ci] = 1;
+        std::u32string expectedFp = survivingFingerprint(wtext, idxMap, redactSet);
 
         // Apply Object Fission redaction (all matches in one pass)
         int32_t rc = objectFissionRedact(pw->doc, pw->page, tp, matches, argb, pw->core);


### PR DESCRIPTION
PII pre-scan uses raw FPDFText_GetText dump; grapheme pass is lazy on zero-match pages. words+PII pipeline: 87ms -> 53ms. Adds S95 perf harness.