### PR TITLE
Repair vips native builds on all platforms

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -599,8 +599,8 @@ jobs:
         run: |
           set -e
           url=$(curl -fsSL https://api.github.com/repos/libvips/build-win64-mxe/releases/latest \
-                | grep -oE 'https://[^"]*vips-dev-w64-all-[0-9.]+\.zip|https://[^"]*vips-dev-w64-webp-[0-9.]+\.zip' | head -n1 || true)
-          [ -z "$url" ] && { echo "No prebuilt libvips Windows zip found - skipping"; exit 0; }
+                | grep -oE 'https://[^"]*vips-dev-x64-all-[0-9.]+\.zip|https://[^"]*vips-dev-x64-web-[0-9.]+\.zip' | head -n1 || true)
+          [ -z "$url" ] && { echo "ERROR: No prebuilt libvips Windows zip found" >&2; exit 1; }
           curl -fsSL "$url" -o /tmp/vips.zip
           mkdir -p /tmp/vips-win && unzip -q /tmp/vips.zip -d /tmp/vips-win
           VIPS_DIR=$(find /tmp/vips-win -maxdepth 2 -name "bin" -type d | head -n1)

--- a/native/build-vips-full-codecs.sh
+++ b/native/build-vips-full-codecs.sh
@@ -80,7 +80,7 @@ build_libheif_linux() {
     echo "==> build-vips-full-codecs.sh: building libheif ${LIBHEIF_TAG} (static codecs)"
     local work
     work="$(mktemp -d)"
-    trap 'rm -rf "$work"' EXIT
+    trap 'rm -rf "$work"' RETURN
 
     $SUDO apt-get remove -y libheif* 2>/dev/null || true
 
@@ -117,7 +117,7 @@ build_vips() {
     echo "==> build-vips-full-codecs.sh: building libvips ${VIPS_TAG}"
     local work
     work="$(mktemp -d)"
-    trap 'rm -rf "$work"' EXIT
+    trap 'rm -rf "$work"' RETURN
 
     if [ "$OS" = darwin ]; then
         local bp


### PR DESCRIPTION
All 5 vips legs failed in the 1.1.4 Central run, so publish never ran.